### PR TITLE
chore: add Makefile to satisfy grader build contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: build
+
+build:
+	cargo build --release
+	cp target/release/hulk-cli ./hulk


### PR DESCRIPTION
## Summary
The grader contract requires `make build` to produce `./hulk` in the repo root.
Currently there is no Makefile.

## Changes
- Added `Makefile` with `build` target that runs `cargo build --release`
  and copies the binary to `./hulk`

## Verified
- `make build` produces `./hulk` ✅
- `./hulk file.hulk` runs correctly ✅
- Follows the minimal example from matcom/compilers/docs/interface.md