### PR TITLE
fix(codegen): fix multilevel inheritance layout and scope ownership

### DIFF
--- a/crates/hulk-codegen/src/layout.rs
+++ b/crates/hulk-codegen/src/layout.rs
@@ -145,15 +145,26 @@ fn build_struct_type<'ctx>(
     let mut attr_names = Vec::new();
     let mut attr_tys = Vec::new();
 
+    // WHY: hierarchy.rs flattens all parent attributes into each descendant's
+    // TypeInfo. Without deduplication, build_struct_type adds "val" once per
+    // ancestor level, so field_offsets["val"] ends up pointing to the last
+    // (deepest) duplicate instead of the root ancestor's offset at 32.
+    // This tracks which attribute names have already been added so each
+    // attribute appears exactly once, at the offset determined by the first
+    // ancestor that declares it (root-first order).
+    let mut seen = std::collections::HashSet::new();
+
     // Helper to add attributes from a given type.
     fn add_attributes_from_type<'a>(
         type_info: &TypeInfo,
         attr_names: &mut Vec<String>,
         attr_tys: &mut Vec<BasicTypeEnum<'a>>,
+        seen: &mut std::collections::HashSet<String>,
         ctx: &CodegenCtx<'a>,
         registry: &TypeRegistry,
     ) -> Result<(), CodegenError> {
         for (name, attr) in &type_info.attributes {
+            if !seen.insert(name.clone()) { continue; }
             let ty = attr
                 .declared_type
                 .as_ref()
@@ -171,11 +182,11 @@ fn build_struct_type<'ctx>(
         let ancestor_info = registry
             .lookup_type(&ancestor_name)
             .ok_or_else(|| CodegenError::llvm_verification(format!("ancestor '{}' not found", ancestor_name)))?;
-        add_attributes_from_type(ancestor_info, &mut attr_names, &mut attr_tys, ctx, registry)?;
+        add_attributes_from_type(ancestor_info, &mut attr_names, &mut attr_tys, &mut seen, ctx, registry)?;
     }
 
     // Add own attributes.
-    add_attributes_from_type(info, &mut attr_names, &mut attr_tys, ctx, registry)?;
+    add_attributes_from_type(info, &mut attr_names, &mut attr_tys, &mut seen, ctx, registry)?;
 
     // ─── 2. Build the struct type ──────────────────────────────────────────
 

--- a/crates/hulk-codegen/src/lower/call.rs
+++ b/crates/hulk-codegen/src/lower/call.rs
@@ -367,8 +367,12 @@ fn lower_base_call<'ctx>(
             )
         })?;
 
-    // Prepare arguments: `self` is the first argument. We need to load `self` from the scope.
-    let self_ptr = ctx
+    // Prepare arguments: `self` is the first argument.
+    // WHY: scope_stack stores the alloca address (.0), not the value it holds.
+    // We must load the actual object pointer out of the alloca before passing it
+    // as `self` to the parent method — otherwise the callee receives the stack
+    // slot address and treats it as the object, reading garbage at offset 32+.
+    let (self_alloca, self_llvm_ty, _) = ctx
         .scope_stack
         .lookup("self")
         .ok_or_else(|| {
@@ -376,10 +380,14 @@ fn lower_base_call<'ctx>(
                 "self not in scope",
                 Some(call.callee.span)
             )
-        })?
-        .0;
+        })?;
+    let self_val = ctx
+        .codegen
+        .builder
+        .build_load(self_llvm_ty, self_alloca, "self_for_base")
+        .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
     let mut args = Vec::new();
-    args.push(self_ptr.into());
+    args.push(self_val.into());
     for arg in &call.args {
         args.push(lower_expr(ctx, arg)?.into());
     }

--- a/crates/hulk-codegen/src/lower/decl.rs
+++ b/crates/hulk-codegen/src/lower/decl.rs
@@ -119,7 +119,7 @@ fn define_function(
         lower_ctx.codegen.builder
             .build_store(alloca, *param_value)
             .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
-        lower_ctx.scope_stack.declare(param_name, alloca, llvm_param_ty, param_ty.clone());
+        lower_ctx.scope_stack.declare(param_name, alloca, llvm_param_ty, param_ty.clone(), false);
     }
 
     // Lower the function body.

--- a/crates/hulk-codegen/src/lower/for_loop.rs
+++ b/crates/hulk-codegen/src/lower/for_loop.rs
@@ -143,7 +143,7 @@ pub fn lower_for<'ctx>(
         .builder
         .build_store(var_ptr, current_val)
         .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
-    ctx.scope_stack.declare(&for_expr.var, var_ptr, elem_llvm_ty, elem_ty.clone());
+    ctx.scope_stack.declare(&for_expr.var, var_ptr, elem_llvm_ty, elem_ty.clone(), false);
 
     // Lower the body.
     let body_val = lower_expr(ctx, body_expr)?;

--- a/crates/hulk-codegen/src/lower/method.rs
+++ b/crates/hulk-codegen/src/lower/method.rs
@@ -152,7 +152,7 @@ fn define_methods_for_type(
             .build_store(self_alloca, self_param)
             .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
         let self_sem_ty = Type::Named(type_name.clone());
-        lower_ctx.scope_stack.declare("self", self_alloca, self_ty.into(), self_sem_ty);
+        lower_ctx.scope_stack.declare("self", self_alloca, self_ty.into(), self_sem_ty, false);
         
         // Bind other parameters.
         for (i, (param_name, param_ty)) in method_sig.params.iter().enumerate() {
@@ -164,7 +164,7 @@ fn define_methods_for_type(
             lower_ctx.codegen.builder
                 .build_store(alloca, param_value)
                 .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
-            lower_ctx.scope_stack.declare(param_name, alloca, llvm_param_ty, param_ty.clone());
+            lower_ctx.scope_stack.declare(param_name, alloca, llvm_param_ty, param_ty.clone(), false);
         }
 
         // Find the corresponding method body in the AST.

--- a/crates/hulk-codegen/src/lower/mod.rs
+++ b/crates/hulk-codegen/src/lower/mod.rs
@@ -103,8 +103,8 @@ impl<'a, 'ctx> LowerCtx<'a, 'ctx> {
         let scope = self.scope_stack.pop_scope();
         let release_fn = self.codegen.functions.get("hulk_rt_release").cloned();
         if let Some(release) = release_fn {
-            for (_name, (ptr, llvm_ty, sem_ty)) in scope {
-                if is_heap_allocated_type(&sem_ty, self.registry) {
+            for (_name, (ptr, llvm_ty, sem_ty, owned)) in scope {
+                if owned && is_heap_allocated_type(&sem_ty, self.registry) {
                     // Load the full value using its stored LLVM type.
                     let val = self.codegen.builder
                         .build_load(llvm_ty, ptr, "scope_exit_load")
@@ -127,7 +127,7 @@ impl<'a, 'ctx> LowerCtx<'a, 'ctx> {
             .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
         self.codegen.builder.build_store(ptr, value)
             .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
-        self.scope_stack.declare(name, ptr, llvm_ty, sem_ty);
+        self.scope_stack.declare(name, ptr, llvm_ty, sem_ty, true);
         Ok(())
     }
 

--- a/crates/hulk-codegen/src/lower/pattern.rs
+++ b/crates/hulk-codegen/src/lower/pattern.rs
@@ -160,7 +160,7 @@ pub fn lower_match<'ctx>(
                 .builder
                 .build_store(ptr, val)
                 .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
-            ctx.scope_stack.declare(&name, ptr, llvm_ty, sem_ty);
+            ctx.scope_stack.declare(&name, ptr, llvm_ty, sem_ty, false);
         }
 
         // Lower the case body.

--- a/crates/hulk-codegen/src/lower/scope.rs
+++ b/crates/hulk-codegen/src/lower/scope.rs
@@ -7,9 +7,13 @@ use inkwell::types::BasicTypeEnum;
 use hulk_semantic::Type;
 
 /// A stack of scopes, each mapping a variable name to its LLVM `alloca` pointer.
+///
+/// Each entry carries an `owned` flag. Only owned bindings (let variables,
+/// constructor arguments) are released by `pop_scope`; borrowed bindings
+/// (`self`, method/function parameters, loop variables) are skipped.
 #[derive(Default)]
 pub struct ScopeStack<'ctx> {
-    scopes: Vec<HashMap<String,(PointerValue<'ctx>, BasicTypeEnum<'ctx>, Type)>>,
+    scopes: Vec<HashMap<String,(PointerValue<'ctx>, BasicTypeEnum<'ctx>, Type, bool)>>,
 }
 
 impl<'ctx> ScopeStack<'ctx> {
@@ -26,22 +30,27 @@ impl<'ctx> ScopeStack<'ctx> {
     ///
     /// # Panics
     /// Panics if there is no scope to pop (i.e., the stack is empty).
-    pub fn pop_scope(&mut self) -> HashMap<String, (PointerValue<'ctx>, BasicTypeEnum<'ctx>, Type)> {
+    pub fn pop_scope(&mut self) -> HashMap<String, (PointerValue<'ctx>, BasicTypeEnum<'ctx>, Type, bool)> {
         self.scopes.pop().expect("scope stack underflow")
     }
 
     /// Declares a variable in the innermost scope.
     ///
+    /// `owned`: if `true`, the binding owns its heap reference and will be
+    /// released when the scope exits. Pass `false` for borrowed bindings
+    /// (`self`, function/method parameters, loop variables) that must not be
+    /// released by the callee — the caller already owns that reference.
+    ///
     /// Overwrites any existing binding with the same name in that scope.
-    pub fn declare(&mut self, name: &str, ptr: PointerValue<'ctx>, llvm_ty: BasicTypeEnum<'ctx>, sem_ty: Type) {
+    pub fn declare(&mut self, name: &str, ptr: PointerValue<'ctx>, llvm_ty: BasicTypeEnum<'ctx>, sem_ty: Type, owned: bool) {
         let scope = self.scopes.last_mut().expect("no scope to declare into");
-        scope.insert(name.to_string(), (ptr, llvm_ty, sem_ty));
+        scope.insert(name.to_string(), (ptr, llvm_ty, sem_ty, owned));
     }
 
     /// Looks up a variable starting from the innermost scope outward.
     pub fn lookup(&self, name: &str) -> Option<(PointerValue<'ctx>, BasicTypeEnum<'ctx>, Type)> {
         for scope in self.scopes.iter().rev() {
-            if let Some((ptr, llvm_ty, sem_ty)) = scope.get(name) {
+            if let Some((ptr, llvm_ty, sem_ty, _owned)) = scope.get(name) {
                 return Some((*ptr, *llvm_ty, sem_ty.clone()));
             }
         }

--- a/crates/hulk-codegen/src/lower/vector.rs
+++ b/crates/hulk-codegen/src/lower/vector.rs
@@ -172,7 +172,7 @@ fn lower_vector_comprehension<'ctx>(
         .builder
         .build_store(var_ptr, current_val)
         .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
-    ctx.scope_stack.declare(&comp.var, var_ptr, elem_llvm_ty, elem_ty.clone());
+    ctx.scope_stack.declare(&comp.var, var_ptr, elem_llvm_ty, elem_ty.clone(), false);
 
     // Lower the head expression.
     let mut head_val = lower_expr(ctx, head_expr)?;


### PR DESCRIPTION
## Summary
Fixes method_override, multilevel, polymorphism — completing 77/77 grader tests
with correct output verified for all 46 ok/ tests.

## Three independent bugs fixed

### Fix 1 — Duplicate attributes in multilevel inheritance layout
hierarchy.rs flattens all parent attributes into each child TypeInfo.
build_struct_type added val once per ancestor, making field_offsets[val]
point to the wrong offset. Added seen HashSet to skip duplicates.

### Fix 2 — pop_scope released borrowed references (self + params)
Methods don't own self or their parameters — the caller does.
pop_scope was unconditionally releasing every heap-allocated scope entry,
freeing the FancyPrinter object mid-method → dangling pointer → crash.
Added owned: bool flag to ScopeStack. Only let bindings are owned=true.
self, method params, loop variables are owned=false → skipped by pop_scope.

### Fix 3 — base call passed alloca address instead of object pointer
lower_base_call passed the stack slot address as self instead of the
heap object pointer. Added explicit build_load to dereference the alloca.

## Verification
- cargo clippy --all-targets -- -D warnings: 0 errors
- cargo test --all --test-threads=1: 207 passed, 0 failed
- Output check: 46/46 ok/ tests produce correct output
- Full grader: **77/77 tests pass**

Closes #27