### PR TITLE
fix(codegen): fix for loop iteration over Range and Vector

### DIFF
--- a/crates/hulk-codegen/src/lower/call.rs
+++ b/crates/hulk-codegen/src/lower/call.rs
@@ -128,6 +128,30 @@ pub fn lower_call<'ctx>(
 /// - Builtin types (`Vector`, `Range`) → direct call to a runtime function.
 /// - Protocol types (`Named` protocol or `Iterable`) → itable dispatch via fat pointer.
 /// - Class types (`Named` type) → vtable dispatch.
+pub fn lower_method_call_val<'ctx>(
+    ctx: &mut LowerCtx<'_, 'ctx>,
+    obj_val: BasicValueEnum<'ctx>,
+    obj_type: &Type,
+    method_name: &str,
+    span: SourceSpan,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    if let Type::Vector(_) = obj_type {
+        return lower_builtin_vector_call(ctx, obj_val, method_name, &[], span);
+    }
+    if let Type::Named(name) = obj_type {
+        if name == "Range" {
+            return lower_builtin_range_call(ctx, obj_val, method_name, &[], span);
+        }
+    }
+    if is_protocol_type(obj_type, ctx.registry) {
+        return lower_protocol_call(ctx, obj_val, obj_type, method_name, &[], span);
+    }
+    Err(CodegenError::unsupported(
+        format!("iterable method `{}` not supported on type `{}`", method_name, obj_type),
+        Some(span),
+    ))
+}
+
 pub fn lower_method_call<'ctx>(
     ctx: &mut LowerCtx<'_, 'ctx>,
     object: TypedExpr,

--- a/crates/hulk-codegen/src/lower/for_loop.rs
+++ b/crates/hulk-codegen/src/lower/for_loop.rs
@@ -6,7 +6,7 @@ use hulk_ast::ForExpr;
 use hulk_semantic::Type;
 
 use crate::error::CodegenError;
-use crate::lower::call::lower_method_call;
+use crate::lower::call::lower_method_call_val;
 use crate::lower::LowerCtx;
 use crate::lower::utils::ensure_unboxed;
 use super::lower_expr;
@@ -23,7 +23,6 @@ pub fn lower_for<'ctx>(
     ctx: &mut LowerCtx<'_, 'ctx>,
     for_expr: &ForExpr<Type>,
 ) -> Result<BasicValueEnum<'ctx>, CodegenError> {
-    // The iterable expression is lowered once, before the loop.
     let iterable_expr = &for_expr.iterable;
     let body_expr = &for_expr.body;
 
@@ -32,11 +31,15 @@ pub fn lower_for<'ctx>(
         .registry
         .lookup_method(&iterable_expr.anno, "current")
         .map(|sig| sig.return_type)
-        .ok_or_else(|| CodegenError::unsupported (
+        .ok_or_else(|| CodegenError::unsupported(
             format!("iterable type `{}` does not support `current()`", iterable_expr.anno),
             Some(iterable_expr.span)
         ))?;
     let elem_llvm_ty = crate::lower::utils::llvm_type(ctx.codegen, ctx.registry, &elem_ty)?;
+
+    // Compute the LLVM type of the iterable itself (needed for the persistent alloca).
+    let iter_ty = iterable_expr.anno.clone();
+    let iter_llvm_ty = crate::lower::utils::llvm_type(ctx.codegen, ctx.registry, &iter_ty)?;
 
     // Result storage: the loop's value is the last body value, or a default.
     let result_ty = crate::lower::utils::llvm_type(ctx.codegen, ctx.registry, &body_expr.anno)?;
@@ -74,7 +77,7 @@ pub fn lower_for<'ctx>(
             BasicValueEnum::StructValue(null_struct)
         }
         _ => {
-            return Err(CodegenError::unsupported (
+            return Err(CodegenError::unsupported(
                 format!("default value for type `{}` not implemented", body_expr.anno),
                 Some(body_expr.span)
             ));
@@ -83,6 +86,22 @@ pub fn lower_for<'ctx>(
     ctx.codegen
         .builder
         .build_store(result_alloca, default_val)
+        .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
+
+    // WHY: Evaluate the iterable expression ONCE here, before entering the loop.
+    // Previously, lower_method_call re-evaluated the receiver expression on every
+    // next()/current() call.  For `range(0,5)` that creates a fresh HulkRange
+    // each iteration, so next() always returns true → infinite loop.  Store the
+    // iterable in a stack slot and load it in both the condition and body blocks.
+    let iter_val = lower_expr(ctx, iterable_expr)?;
+    let iter_alloca = ctx
+        .codegen
+        .builder
+        .build_alloca(iter_llvm_ty, "iter_obj")
+        .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
+    ctx.codegen
+        .builder
+        .build_store(iter_alloca, iter_val)
         .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
 
     // Basic blocks.
@@ -106,14 +125,11 @@ pub fn lower_for<'ctx>(
     // ── Condition block ─────────────────────────────────────────────────
     ctx.codegen.builder.position_at_end(cond_bb);
 
-    // Call `next()` on the iterable; returns a boolean.
-    let next_val = lower_method_call(
-        ctx,
-        (**iterable_expr).clone(),
-        "next",
-        &[],
-        iterable_expr.span,
-    )?;
+    // Load the persistent iterable and call next().
+    let iter_for_next = ctx.codegen.builder
+        .build_load(iter_llvm_ty, iter_alloca, "iter_next_load")
+        .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
+    let next_val = lower_method_call_val(ctx, iter_for_next, &iter_ty, "next", iterable_expr.span)?;
     let next_bool = next_val.into_int_value();
 
     ctx.codegen
@@ -124,17 +140,19 @@ pub fn lower_for<'ctx>(
     // ── Body block ──────────────────────────────────────────────────────
     ctx.codegen.builder.position_at_end(body_bb);
 
-    // Call `current()` to get the element.
-    let current_val = lower_method_call(
-        ctx,
-        (**iterable_expr).clone(),
-        "current",
-        &[],
-        iterable_expr.span,
-    )?;
+    // Load the persistent iterable and call current().
+    let iter_for_current = ctx.codegen.builder
+        .build_load(iter_llvm_ty, iter_alloca, "iter_current_load")
+        .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
+    let current_val = lower_method_call_val(ctx, iter_for_current, &iter_ty, "current", iterable_expr.span)?;
 
-    // Unbox if the element type is primitive
-    let unboxed_current = ensure_unboxed(ctx, current_val, &elem_ty)?;
+    // WHY: hulk_rt_range_current returns f64 directly (never boxed).
+    // hulk_rt_vector_current returns HulkBox* (needs unboxing for primitive elements).
+    let unboxed_current = if matches!(&iter_ty, Type::Named(n) if n == "Range") {
+        current_val
+    } else {
+        ensure_unboxed(ctx, current_val, &elem_ty)?
+    };
 
     // Bind the loop variable.
     ctx.push_scope();

--- a/crates/hulk-codegen/src/lower/utils.rs
+++ b/crates/hulk-codegen/src/lower/utils.rs
@@ -449,7 +449,7 @@ pub fn ensure_unboxed<'ctx>(
             let val = ctx.codegen.builder
                 .build_load(ctx.codegen.context.f64_type(), payload_typed_ptr, "unbox_num")
                 .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
-            Ok(val.into())
+            Ok(val)
         }
         Type::Boolean => {
             let val = ctx.codegen.builder


### PR DESCRIPTION
## Summary
Fixes 7 extras/for_* and range_* tests that crashed with exit 139.
Verified: 10/10 extras pass locally (vs 3/10 in main before this fix).

## Two bugs fixed

### Bug 1: Iterable re-evaluated on every iteration
Iterable expression re-evaluated each iteration → fresh Range every time
→ next() always true → crash. Fix: evaluate once, store in alloca,
reuse via new lower_method_call_val helper.

### Bug 2: ensure_unboxed panicked on FloatValue
hulk_rt_range_current returns f64 directly. ensure_unboxed assumed
PointerValue. Fix: dispatch on semantic type.

## Verification
- cargo clippy --all-targets: 0 errors
- cargo test --all: 207 passed, 0 failed
- 77/77 required tests pass, no regressions
- 10/10 extras pass locally

Closes #29