### PR TITLE
feat(codegen): Implement vector indexing

### DIFF
--- a/crates/hulk-codegen/src/lower/binding.rs
+++ b/crates/hulk-codegen/src/lower/binding.rs
@@ -14,13 +14,14 @@
 //! - A plain `Block` does not introduce a new scope (handled in `control.rs`).
 
 use inkwell::values::BasicValueEnum;
-use hulk_ast::{AssignExpr, LetExpr, SourceSpan};
+use hulk_ast::{AssignExpr, AssignTarget, LetExpr, SourceSpan};
 use hulk_semantic::Type;
 
 use crate::error::CodegenError;
 use crate::lower::LowerCtx;
 use crate::lower::utils::{resolve_attribute_with_offset, resolve_type_ref_to_type, convert_to_protocol, is_heap_allocated_type, is_protocol_or_iterable};
 use crate::lower::builtins::lookup_constant;
+use crate::lower::index;
 use super::lower_expr;
 
 /// Lowers a variable reference.
@@ -142,7 +143,7 @@ pub fn lower_assign<'ctx>(
     assign: &AssignExpr<Type>,
 ) -> Result<inkwell::values::BasicValueEnum<'ctx>, CodegenError> {
     match &assign.target {
-        hulk_ast::AssignTarget::Variable(name) => {
+        AssignTarget::Variable(name) => {
             // 1. Look up the variable's LLVM pointer and semantic type.
             let (ptr, _llvm_ty, target_ty) = ctx.lookup_var(name, Some(assign.value.span))?;
 
@@ -207,7 +208,7 @@ pub fn lower_assign<'ctx>(
             // 7. The assignment expression returns the stored value.
             Ok(stored_val)
         }
-        hulk_ast::AssignTarget::Member { object, field } => {
+        AssignTarget::Member { object, field } => {
             // 1. Lower the object expression to get a pointer.
             let obj_val = lower_expr(ctx, object)?;
             let obj_ptr = obj_val.into_pointer_value();
@@ -290,6 +291,9 @@ pub fn lower_assign<'ctx>(
             // 9. Assignment expression returns the value.
             Ok(val)
         }
-        _ => Err(CodegenError::unsupported("invalid assignment to non-variable target", Some(assign.value.span),))
+        AssignTarget::Index { object, index } => {
+            // Delegate to the index lowering utility.
+            index::lower_index_set(ctx, object, index, &assign.value, assign.value.span)
+        }
     }
 }

--- a/crates/hulk-codegen/src/lower/index.rs
+++ b/crates/hulk-codegen/src/lower/index.rs
@@ -1,0 +1,169 @@
+//! Lowering of vector indexing expressions (`expr[index]`).
+//!
+//! This module handles the code generation for reading an element from a vector
+//! using the bracket syntax. It lowers the object and index expressions,
+//! calls the runtime `hulk_rt_vector_get` function, and unboxes the result
+//! if the element type is a primitive (`Number` or `Boolean`). The runtime 
+//! stores elements as boxed `Object*` pointers, so we must unbox primitive 
+//! values to their raw representation before returning them.
+//!
+//! # Related
+//! - For assignment `a[i] := v`, see `lower::binding::lower_assign`.
+//! - For unboxing logic, see `lower::utils::ensure_unboxed`.
+
+use inkwell::values::BasicValueEnum;
+
+use hulk_ast::{IndexExpr, SourceSpan};
+use hulk_semantic::Type;
+
+use crate::error::CodegenError;
+use crate::lower::LowerCtx;
+use crate::lower::utils::ensure_unboxed;
+use super::lower_expr;
+
+/// Lowers a vector indexing expression `object[index]`.
+///
+/// # Steps
+/// 1. Lower the `object` expression to obtain a pointer to the vector.
+/// 2. Lower the `index` expression (must be a `Number`) and convert it to `i64`.
+/// 3. Call the runtime function `hulk_rt_vector_get(vec_ptr, index)` to obtain
+///    the boxed element pointer.
+/// 4. Unbox the pointer if the static element type is `Number` or `Boolean`.
+/// 5. Return the raw value.
+///
+/// # Parameters
+/// - `ctx`: The lowering context.
+/// - `index_expr`: The AST node for the indexing expression.
+/// - `expr_anno`: The static element type (from semantic analysis), used to
+///   determine whether unboxing is required.
+/// - `span`: The source span for error reporting.
+///
+/// # Returns
+/// The LLVM value representing the element, either raw (for primitives) or
+/// a pointer (for heap‑allocated types like `String`, `Object`, or `Named`).
+///
+/// # Errors
+/// - `CodegenError::Unsupported` if the runtime function `hulk_rt_vector_get`
+///   is not declared (should never happen after `runtime_decls::declare_all`).
+/// - Propagates errors from lowering the object or index expressions.
+pub fn lower_index_get<'ctx>(
+    ctx: &mut LowerCtx<'_, 'ctx>,
+    index_expr: &IndexExpr<Type>,
+    expr_anno: &Type,
+    span: SourceSpan,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    // 1. Lower the object expression (must be a vector pointer).
+    let obj_val = lower_expr(ctx, &index_expr.object)?;
+    let vec_ptr = obj_val.into_pointer_value();
+
+    // 2. Lower the index expression (must be a Number).
+    let idx_val = lower_expr(ctx, &index_expr.index)?;
+    let idx_f64 = idx_val.into_float_value();
+    let idx_i64 = ctx
+        .codegen
+        .builder
+        .build_float_to_signed_int(idx_f64, ctx.codegen.context.i64_type(), "idx_cast")
+        .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
+
+    // 3. Retrieve the runtime `vector_get` function.
+    let get_fn = ctx
+        .codegen
+        .functions
+        .get("hulk_rt_vector_get")
+        .copied()
+        .ok_or_else(|| {
+            CodegenError::unsupported(
+                "hulk_rt_vector_get not declared in module",
+                Some(span),
+            )
+        })?;
+
+    // 4. Call `hulk_rt_vector_get(vec_ptr, idx)`.
+    let call_result = ctx
+        .codegen
+        .builder
+        .build_call(get_fn, &[vec_ptr.into(), idx_i64.into()], "vec_get")
+        .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
+    let elem_ptr = call_result
+        .try_as_basic_value()
+        .unwrap_basic(); // safe: function returns a pointer
+
+    // 5. Unbox if the element type is primitive.
+    let unboxed = ensure_unboxed(ctx, elem_ptr, expr_anno)?;
+
+    Ok(unboxed)
+}
+
+/// Lowers a vector index assignment `object[index] := value`.
+///
+/// # Steps
+/// 1. Lower the `object` expression to obtain a pointer to the vector.
+/// 2. Lower the `index` expression (must be a `Number`) and convert it to `i64`.
+/// 3. Lower the `value` expression and box it if it is a primitive
+///    (`Number` or `Boolean`) because vectors store `Object*`.
+/// 4. Call the runtime function `hulk_rt_vector_set(vec_ptr, index, value)`.
+/// 5. Return the assigned value (the value after boxing, for consistency).
+///
+/// # Parameters
+/// - `ctx`: The lowering context.
+/// - `object`: The vector expression.
+/// - `index`: The index expression.
+/// - `value`: The value to store.
+/// - `span`: The source span for error reporting.
+///
+/// # Returns
+/// The LLVM value that was stored (boxed if primitive, otherwise unchanged).
+///
+/// # Errors
+/// - `CodegenError::Unsupported` if the runtime function `hulk_rt_vector_set`
+///   is not declared.
+/// - Propagates errors from lowering the object, index, or value expressions.
+pub fn lower_index_set<'ctx>(
+    ctx: &mut LowerCtx<'_, 'ctx>,
+    object: &hulk_ast::Expr<Type>,
+    index: &hulk_ast::Expr<Type>,
+    value: &hulk_ast::Expr<Type>,
+    span: SourceSpan,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    // 1. Lower the object expression (must be a vector pointer).
+    let obj_val = lower_expr(ctx, object)?;
+    let vec_ptr = obj_val.into_pointer_value();
+
+    // 2. Lower the index expression (must be a Number) and cast to i64.
+    let idx_val = lower_expr(ctx, index)?;
+    let idx_f64 = idx_val.into_float_value();
+    let idx_i64 = ctx
+        .codegen
+        .builder
+        .build_float_to_signed_int(idx_f64, ctx.codegen.context.i64_type(), "idx_cast")
+        .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
+
+    // 3. Lower the value to be stored.
+    let val = lower_expr(ctx, value)?;
+    let val_ty = &value.anno;
+
+    // 4. Box primitive values if needed.
+    let boxed_val = crate::lower::utils::ensure_boxed(ctx, val, val_ty, &Type::Object)?;
+
+    // 5. Retrieve the runtime `vector_set` function.
+    let set_fn = ctx
+        .codegen
+        .functions
+        .get("hulk_rt_vector_set")
+        .copied()
+        .ok_or_else(|| {
+            CodegenError::unsupported(
+                "hulk_rt_vector_set not declared in module",
+                Some(span),
+            )
+        })?;
+
+    // 6. Call hulk_rt_vector_set(vec_ptr, idx, boxed_val).
+    ctx.codegen
+        .builder
+        .build_call(set_fn, &[vec_ptr.into(), idx_i64.into(), boxed_val.into()], "vec_set")
+        .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
+
+    // 7. Return the boxed value (the assignment expression returns the stored value).
+    Ok(boxed_val)
+}

--- a/crates/hulk-codegen/src/lower/mod.rs
+++ b/crates/hulk-codegen/src/lower/mod.rs
@@ -43,6 +43,7 @@ pub mod vector;
 pub mod for_loop;
 pub mod pattern;
 pub mod builtins;
+pub mod index;
 
 // ─── Lowering context ────────────────────────────────────────────────────
 
@@ -191,7 +192,8 @@ pub fn lower_expr<'ctx>(
         ExprKind::Variable(name) => binding::lower_variable(ctx, name, Some(expr.span)),
         ExprKind::SelfRef => binding::lower_variable(ctx, "self", Some(expr.span)),
         ExprKind::Vector(vector) => vector::lower_vector(ctx, vector, &expr.anno, expr.span),
-
+        ExprKind::Index(index_expr) => index::lower_index_get(ctx, index_expr, &expr.anno, expr.span),
+        
         // ─── Unary and binary operators ──────────────────────────────────
 
         ExprKind::Unary(unary) => operators::lower_unary(ctx, unary),
@@ -220,14 +222,6 @@ pub fn lower_expr<'ctx>(
         ExprKind::TypeTest(type_test) => type_ops::lower_typetest(ctx, type_test),
         ExprKind::Downcast(downcast) => type_ops::lower_downcast(ctx, downcast),
 
-        // ─── Deferred to later phases ────────────────────────────────────
-
-        ExprKind::Index(_) => {
-            Err(CodegenError::unsupported (
-                "indexing not yet supported",
-                Some(expr.span)
-            ))
-        }
         // ─── Catch-all for unhandled cases ───────────────────────────────
         _ => Err(CodegenError::unsupported (
             format!("lowering of {:?} not yet implemented or unsupported", expr.kind),


### PR DESCRIPTION
- ADD lower/index.rs: Implement vector index read (`a[i]`) via `lower_index_get()` and vector index write (`a[i] := v`) via `lower_index_set()`. To get, lowers the object and index, calls `hulk_rt_vector_get`, and unboxes the result if the element type is primitive. To set uses `ensure_boxed()` to box primitive values before calling `hulk_rt_vector_set`.

- MODIFY lower/mod.rs: Include new indexing get functionality.

- MODIFY lower/mod.rs: Include new indexing set functionality.