### PR TITLE
feat(codegen): implement lambda expressions (Phase 1)

### DIFF
--- a/crates/hulk-ast/src/lib.rs
+++ b/crates/hulk-ast/src/lib.rs
@@ -251,7 +251,15 @@ impl TypeRef {
 
 impl fmt::Display for TypeRef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.args.is_empty() {
+        if self.name == "Function" && !self.args.is_empty() {
+            let return_type = self.args.last().expect("function type has return type");
+            let params = self.args[..self.args.len() - 1]
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            write!(f, "({}) -> {}", params, return_type)
+        } else if self.args.is_empty() {
             write!(f, "{}", self.name)
         } else {
             let args = self
@@ -353,6 +361,7 @@ pub enum ExprKind<A = ()> {
     While(WhileExpr<A>),
     For(ForExpr<A>),
     Call(CallExpr<A>),
+    Lambda(LambdaExpr<A>),
     Member(MemberExpr<A>),
     New(NewExpr<A>),
     TypeTest(TypeTestExpr<A>),
@@ -574,6 +583,27 @@ pub struct CallExpr<A = ()> {
     pub args: Vec<Expr<A>>,
 }
 
+/// Anonymous function expression: `(x: T, y) => body`.
+///
+/// The body is still a HULK expression, so both inline expression bodies and
+/// block bodies are represented without needing a separate return statement.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LambdaExpr<A = ()> {
+    pub params: Vec<Param>,
+    pub return_type: Option<TypeRef>,
+    pub body: Box<Expr<A>>,
+}
+
+impl<A> LambdaExpr<A> {
+    pub fn new(params: Vec<Param>, return_type: Option<TypeRef>, body: Expr<A>) -> Self {
+        Self {
+            params,
+            return_type,
+            body: Box::new(body),
+        }
+    }
+}
+
 /// Dot access: `object.member`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MemberExpr<A = ()> {
@@ -778,6 +808,7 @@ where
                 walk_expr(arg, visit);
             }
         }
+        ExprKind::Lambda(lambda) => walk_expr(&lambda.body, visit),
         ExprKind::Member(member) => walk_expr(&member.object, visit),
         ExprKind::New(new_expr) => {
             for arg in &new_expr.args {
@@ -865,6 +896,15 @@ mod tests {
     fn type_ref_display_with_args() {
         let t = TypeRef::with_args("Iterable", vec![TypeRef::named("Number")]);
         assert_eq!(t.to_string(), "Iterable<Number>");
+    }
+
+    #[test]
+    fn type_ref_display_function_type() {
+        let t = TypeRef::with_args(
+            "Function",
+            vec![TypeRef::named("Number"), TypeRef::named("Boolean")],
+        );
+        assert_eq!(t.to_string(), "(Number) -> Boolean");
     }
 
     #[test]

--- a/crates/hulk-codegen/src/context.rs
+++ b/crates/hulk-codegen/src/context.rs
@@ -25,6 +25,8 @@ pub struct CodegenCtx<'ctx> {
     pub functions: HashMap<String, FunctionValue<'ctx>>,
     /// Monotonically increasing id used to give every string-literal global a unique name
     string_literal_count: u32,
+    /// Monotonically increasing id used to give every lambda function a unique name
+    lambda_count: u32,
     /// Type layouts for user‑defined classes.
     pub type_layouts: HashMap<String, TypeLayout<'ctx>>,
     /// The target machine this module is built for. Owned here rather than re-created
@@ -50,6 +52,7 @@ impl<'ctx> CodegenCtx<'ctx> {
             builder,
             functions: HashMap::new(),
             string_literal_count: 0,
+            lambda_count: 0,
             type_layouts: HashMap::new(),
             target_machine,
             itables: HashMap::new(),
@@ -59,6 +62,12 @@ impl<'ctx> CodegenCtx<'ctx> {
     pub fn next_string_literal_id(&mut self) -> u32 {
         let id = self.string_literal_count;
         self.string_literal_count += 1;
+        id
+    }
+
+    pub fn next_lambda_id(&mut self) -> u32 {
+        let id = self.lambda_count;
+        self.lambda_count += 1;
         id
     }
 }

--- a/crates/hulk-codegen/src/itables.rs
+++ b/crates/hulk-codegen/src/itables.rs
@@ -218,6 +218,10 @@ fn collect_used_pairs(program: &Program<Type>, registry: &TypeRegistry) -> HashS
                 walk_expr(&call.callee, None, registry, pairs, visitor);
             }
 
+            ExprKind::Lambda(lambda) => {
+                walk_expr(&lambda.body, None, registry, pairs, visitor);
+            }
+
             ExprKind::Member(member) => {
                 walk_expr(&member.object, None, registry, pairs, visitor);
             }

--- a/crates/hulk-codegen/src/lower/lambda.rs
+++ b/crates/hulk-codegen/src/lower/lambda.rs
@@ -1,0 +1,101 @@
+//! Lambda expression lowering.
+//!
+//! WHY: Type::Function uses a uniform { env_ptr, fn_ptr } fat-pointer
+//! representation (same ABI as protocols/Iterable — see utils.rs llvm_type).
+//! This is the standard "uniform calling convention" (cf. Rust RFC 1558,
+//! OCaml): a function with no captures is simply a closure whose env_ptr is
+//! null. lower_function_value in call.rs always destructures the same
+//! { env_ptr, fn_ptr } shape regardless of whether env_ptr is used.
+
+use hulk_ast::LambdaExpr;
+use hulk_semantic::Type;
+use inkwell::types::{BasicMetadataTypeEnum, BasicType};
+use inkwell::values::BasicValueEnum;
+
+use super::lower_expr;
+use crate::error::CodegenError;
+use crate::lower::utils::llvm_type;
+use crate::lower::LowerCtx;
+
+pub fn lower_lambda<'ctx>(
+    ctx: &mut LowerCtx<'_, 'ctx>,
+    lambda: &LambdaExpr<Type>,
+    lambda_type: &Type,
+) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+    let (param_types, return_type) = match lambda_type {
+        Type::Function {
+            params,
+            return_type,
+        } => (params.as_slice(), return_type.as_ref()),
+        _ => {
+            return Err(CodegenError::unsupported(
+                format!("lambda expression has non-Function type `{}`", lambda_type),
+                None,
+            ))
+        }
+    };
+
+    let ptr_type = ctx.codegen.context.ptr_type(Default::default());
+
+    // Build LLVM param types: (ptr env_ignored, user_params...) to match the
+    // calling convention that lower_function_value uses when calling through the
+    // { env_ptr, fn_ptr } fat pointer.
+    let mut llvm_params: Vec<BasicMetadataTypeEnum> = vec![ptr_type.into()];
+    for ty in param_types {
+        llvm_params.push(llvm_type(ctx.codegen, ctx.registry, ty)?.into());
+    }
+    let llvm_return = llvm_type(ctx.codegen, ctx.registry, return_type)?;
+    let fn_type = llvm_return.fn_type(&llvm_params, false);
+
+    let name = format!("lambda_{}", ctx.codegen.next_lambda_id());
+    let lambda_fn = ctx.codegen.module.add_function(&name, fn_type, None);
+
+    // Save the outer function's insertion point so we can restore it after
+    // emitting the lambda body.
+    let saved_bb = ctx.codegen.builder.get_insert_block();
+
+    let entry_bb = ctx.codegen.context.append_basic_block(lambda_fn, "entry");
+    ctx.codegen.builder.position_at_end(entry_bb);
+
+    // Bind user params (index 0 = env_ptr is ignored; user params start at 1).
+    ctx.push_scope();
+    let param_values = lambda_fn.get_params();
+    for (i, param) in lambda.params.iter().enumerate() {
+        let param_ty = &param_types[i];
+        let param_llvm_ty = llvm_type(ctx.codegen, ctx.registry, param_ty)?;
+        let param_val = param_values[i + 1];
+        let alloca = ctx
+            .codegen
+            .builder
+            .build_alloca(param_llvm_ty, &param.name)
+            .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
+        ctx.codegen
+            .builder
+            .build_store(alloca, param_val)
+            .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
+        ctx.scope_stack
+            .declare(&param.name, alloca, param_llvm_ty, param_ty.clone(), false);
+    }
+
+    let body_val = lower_expr(ctx, &lambda.body)?;
+    ctx.pop_scope()?;
+
+    ctx.codegen
+        .builder
+        .build_return(Some(&body_val))
+        .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
+
+    // Restore the outer function's insertion point.
+    if let Some(bb) = saved_bb {
+        ctx.codegen.builder.position_at_end(bb);
+    }
+
+    // Return { null_env_ptr, fn_addr } — matches llvm_type(Type::Function).
+    let null_ptr = ptr_type.const_null();
+    let fn_addr = lambda_fn.as_global_value().as_pointer_value();
+    let fat_ptr = ctx
+        .codegen
+        .context
+        .const_struct(&[null_ptr.into(), fn_addr.into()], false);
+    Ok(fat_ptr.into())
+}

--- a/crates/hulk-codegen/src/lower/mod.rs
+++ b/crates/hulk-codegen/src/lower/mod.rs
@@ -34,6 +34,7 @@ pub mod control;
 pub mod decl;
 pub mod for_loop;
 pub mod index;
+pub mod lambda;
 pub mod literal;
 pub mod member;
 pub mod method;
@@ -246,6 +247,9 @@ pub fn lower_expr<'ctx>(
         ExprKind::Call(call) => call::lower_call(ctx, call),
         ExprKind::New(new_expr) => new::lower_new(ctx, new_expr, Some(expr.span)),
         ExprKind::Member(member_expr) => member::lower_member(ctx, member_expr, Some(expr.span)),
+
+        // ─── Lambda expressions ───────────────────────────────────────────────
+        ExprKind::Lambda(lambda_expr) => lambda::lower_lambda(ctx, lambda_expr, &expr.anno),
 
         // ─── Type tests and downcasts ──────────────────────────────────────────
         ExprKind::TypeTest(type_test) => type_ops::lower_typetest(ctx, type_test),

--- a/crates/hulk-codegen/src/lower/utils.rs
+++ b/crates/hulk-codegen/src/lower/utils.rs
@@ -300,6 +300,20 @@ pub fn resolve_type_ref_to_type(tr: &TypeRef, registry: &TypeRegistry) -> Type {
             Type::Vector(Box::new(Type::Unknown))
         }
         "Iterable" if !tr.args.is_empty() => Type::Iterable(Box::new(Type::Unknown)),
+        "Function" if !tr.args.is_empty() => {
+            let mut params = Vec::new();
+            for arg in &tr.args[..tr.args.len() - 1] {
+                params.push(resolve_type_ref_to_type(arg, registry));
+            }
+            let return_type = resolve_type_ref_to_type(
+                tr.args.last().expect("function type has return type"),
+                registry,
+            );
+            Type::Function {
+                params,
+                return_type: Box::new(return_type),
+            }
+        }
         name => {
             // It could be a user‑defined type or protocol.
             if registry.types.contains_key(name) || registry.protocols.contains_key(name) {

--- a/crates/hulk-lexer/src/lib.rs
+++ b/crates/hulk-lexer/src/lib.rs
@@ -450,7 +450,7 @@ impl Lexer {
             "as" => TokenKind::As,
             "protocol" => TokenKind::Protocol,
             "extends" => TokenKind::Extends,
-            "define" => TokenKind::Def,
+            "def" | "define" => TokenKind::Def,
             "match" => TokenKind::Match,
             "case" => TokenKind::Case,
             // Not a keyword — it's a user-defined identifier.
@@ -613,6 +613,11 @@ mod tests {
     #[test]
     fn test_keyword_if() {
         assert_eq!(lex("if"), vec![TokenKind::If, TokenKind::Eof]);
+    }
+
+    #[test]
+    fn test_keyword_def() {
+        assert_eq!(lex("def"), vec![TokenKind::Def, TokenKind::Eof]);
     }
 
     #[test]

--- a/crates/hulk-parser/GRAMMAR_LL1.md
+++ b/crates/hulk-parser/GRAMMAR_LL1.md
@@ -13,12 +13,17 @@ parser because semantic actions can construct the AST directly.
 
 ```ebnf
 Program      -> Declaration* Expr ';'* EOF
-Declaration  -> FunctionDecl | TypeDecl | ProtocolDecl
+Declaration  -> FunctionDecl | MacroDecl | TypeDecl | ProtocolDecl
 
 FunctionDecl -> 'function' id FunctionTail
+MacroDecl    -> 'def' id FunctionTail
 FunctionTail -> ParamList ReturnType? FunctionBody
 ReturnType   -> ':' TypeRef
-FunctionBody -> '=>' Expr ';'? | Block
+TypeRef      -> FunctionType | IterablePrefix? NamedTypeRef TypeSuffix*
+FunctionType -> '(' (TypeRef (',' TypeRef)*)? ')' '->' TypeRef
+IterablePrefix -> '*'
+TypeSuffix   -> '[]' | '*'
+FunctionBody -> ('=>' | '->') Expr ';'? | Block
 
 TypeDecl     -> 'type' id ParamList? Parent? '{' TypeMember* '}'
 Parent       -> 'inherits' id ConstructorArgs?
@@ -88,6 +93,7 @@ Primary -> number
          | id
          | 'self'
          | 'base'
+         | Lambda
          | '(' Expr ')'
          | Block
          | Vector
@@ -97,6 +103,23 @@ Primary -> number
          | For
          | New
          | Match
+```
+
+## Lambda, vector and type sugar
+
+```ebnf
+Lambda      -> '(' ParamListBody ')' ReturnType? '=>' Expr
+```
+
+The parser peeks through a parenthesized prefix to distinguish `(x) => ...`
+from a normal parenthesized expression. Type annotations also support function
+types, vector sugar and iterable sugar:
+
+```hulk
+(Number[]) -> Boolean   // Function<Vector<Number>, Boolean>
+Number[]                // Vector<Number>
+*Number[]               // Iterable<Number>
+Number*                 // Iterable<Number>, kept for reference compatibility
 ```
 
 ## Vector ambiguity resolution
@@ -124,7 +147,7 @@ parenthesized inside the head.
 | --- | --- |
 | `Program` | `parse_program` |
 | `Declaration` | `parse_declaration` |
-| `FunctionDecl` | `parse_function_declaration_after_keyword` |
+| `FunctionDecl` / `MacroDecl` | `parse_function_declaration_after_keyword` |
 | `TypeDecl` | `parse_type_declaration_after_keyword` |
 | `ProtocolDecl` | `parse_protocol_declaration_after_keyword` |
 | `Expr` | `parse_expression` |
@@ -141,3 +164,5 @@ parenthesized inside the head.
 | `Power` | `parse_power` |
 | `Postfix` | `parse_postfix` |
 | `Primary` | `parse_primary` |
+| `Lambda` | `parse_lambda_expression` |
+| `TypeRef` | `parse_type_ref` |

--- a/crates/hulk-parser/src/lib.rs
+++ b/crates/hulk-parser/src/lib.rs
@@ -19,9 +19,8 @@ use hulk_ast::{
     AssignExpr, AssignTarget, AttributeDecl, BinaryOp, BlockExpr, Declaration, DeclarationKind,
     DowncastExpr, ElifBranch, Expr, ExprKind, ForExpr, FunctionDecl, IfExpr, IndexExpr, LambdaExpr,
     LetBinding, LetExpr, Literal, MatchCase, MatchExpr, MemberExpr, NewExpr, Param, Pattern,
-    Program,
-    ProtocolDecl, ProtocolMethod, SourceSpan, TypeDecl, TypeMember, TypeMemberKind, TypeParent,
-    TypeRef, TypeTestExpr, UnaryOp, VectorComprehension, VectorExpr, WhileExpr,
+    Program, ProtocolDecl, ProtocolMethod, SourceSpan, TypeDecl, TypeMember, TypeMemberKind,
+    TypeParent, TypeRef, TypeTestExpr, UnaryOp, VectorComprehension, VectorExpr, WhileExpr,
 };
 use hulk_lexer::{Span, Token, TokenKind};
 
@@ -757,6 +756,7 @@ impl Ll1Parser {
             TokenKind::For => self.finish_for_expression(span),
             TokenKind::New => self.finish_new_expression(span),
             TokenKind::Match => self.finish_match_expression(span),
+            TokenKind::Function => self.parse_anon_function_after_keyword(span),
             other => Err(ParseError::new(
                 ParseErrorKind::ExpectedExpression {
                     found: token_kind_name(&other),
@@ -764,6 +764,28 @@ impl Ll1Parser {
                 span,
             )),
         }
+    }
+
+    fn parse_anon_function_after_keyword(&mut self, span: SourceSpan) -> Result<Expr, ParseError> {
+        let params = self.parse_param_list()?;
+        let return_type = if self.match_kind(&TokenKind::Colon) {
+            Some(self.parse_type_ref()?)
+        } else {
+            None
+        };
+        let body = if self.match_kind(&TokenKind::FatArrow) || self.match_kind(&TokenKind::Arrow) {
+            let expression = self.parse_expression()?;
+            self.match_kind(&TokenKind::Semicolon);
+            expression
+        } else if self.check(&TokenKind::LBrace) {
+            self.parse_block_expression()?
+        } else {
+            return Err(self.error_unexpected("`=>`, `->`, or function block"));
+        };
+        Ok(Expr::new(
+            ExprKind::Lambda(LambdaExpr::new(params, return_type, body)),
+            span,
+        ))
     }
 
     fn parse_lambda_expression(&mut self) -> Result<Expr, ParseError> {
@@ -1009,7 +1031,11 @@ impl Ll1Parser {
         };
 
         let mut cursor = close_paren + 1;
-        if self.token_at(cursor).map(|k| same_variant(k, &TokenKind::Colon)).unwrap_or(false) {
+        if self
+            .token_at(cursor)
+            .map(|k| same_variant(k, &TokenKind::Colon))
+            .unwrap_or(false)
+        {
             cursor += 1;
             cursor = self.skip_type_ref_tokens(cursor);
         }
@@ -1046,7 +1072,10 @@ impl Ll1Parser {
         while let Some(kind) = self.token_at(index) {
             match kind {
                 TokenKind::FatArrow | TokenKind::Eof
-                    if angle_depth == 0 && paren_depth == 0 && bracket_depth == 0 => break,
+                    if angle_depth == 0 && paren_depth == 0 && bracket_depth == 0 =>
+                {
+                    break
+                }
                 TokenKind::LParen => paren_depth += 1,
                 TokenKind::RParen => {
                     if paren_depth == 0 && angle_depth == 0 && bracket_depth == 0 {
@@ -1114,6 +1143,7 @@ impl Ll1Parser {
                 | TokenKind::For
                 | TokenKind::New
                 | TokenKind::Match
+                | TokenKind::Function
         )
     }
 
@@ -1433,7 +1463,6 @@ mod tests {
             other => panic!("expected let entry, got {other:?}"),
         }
     }
-
 
     #[test]
     fn parses_lambda_expression() {

--- a/crates/hulk-parser/src/lib.rs
+++ b/crates/hulk-parser/src/lib.rs
@@ -17,8 +17,9 @@ use std::fmt;
 
 use hulk_ast::{
     AssignExpr, AssignTarget, AttributeDecl, BinaryOp, BlockExpr, Declaration, DeclarationKind,
-    DowncastExpr, ElifBranch, Expr, ExprKind, ForExpr, FunctionDecl, IfExpr, IndexExpr, LetBinding,
-    LetExpr, Literal, MatchCase, MatchExpr, MemberExpr, NewExpr, Param, Pattern, Program,
+    DowncastExpr, ElifBranch, Expr, ExprKind, ForExpr, FunctionDecl, IfExpr, IndexExpr, LambdaExpr,
+    LetBinding, LetExpr, Literal, MatchCase, MatchExpr, MemberExpr, NewExpr, Param, Pattern,
+    Program,
     ProtocolDecl, ProtocolMethod, SourceSpan, TypeDecl, TypeMember, TypeMemberKind, TypeParent,
     TypeRef, TypeTestExpr, UnaryOp, VectorComprehension, VectorExpr, WhileExpr,
 };
@@ -150,8 +151,8 @@ impl Ll1Parser {
         let span = self.peek_span();
 
         match &self.peek().kind {
-            // WHY: 'define' is syntactically identical to 'function'.
-            // TokenKind::Def is already emitted by the lexer for the 'define' keyword.
+            // WHY: 'def' macros are parsed as global function-like declarations here.
+            // Later phases may choose to transpile them differently.
             TokenKind::Function | TokenKind::Def => {
                 self.advance();
                 let function = self.parse_function_declaration_after_keyword()?;
@@ -189,7 +190,7 @@ impl Ll1Parser {
 
         // WHY: HULK spec uses `=>` for function bodies, but the 'define' macro
         // extension conventionally uses `->` (same token as function-type arrows).
-        // Accept both so `define f(x): T -> expr` and `function f(x): T => expr`
+        // Accept both so `def f(x): T -> expr` and `function f(x): T => expr`
         // work identically.
         let body = if self.match_kind(&TokenKind::FatArrow) || self.match_kind(&TokenKind::Arrow) {
             let expression = self.parse_expression()?;
@@ -306,6 +307,10 @@ impl Ll1Parser {
 
     fn parse_param_list(&mut self) -> Result<Vec<Param>, ParseError> {
         self.consume(&TokenKind::LParen, "`(` before parameter list")?;
+        self.parse_param_list_after_lparen()
+    }
+
+    fn parse_param_list_after_lparen(&mut self) -> Result<Vec<Param>, ParseError> {
         let mut params = Vec::new();
 
         if !self.check(&TokenKind::RParen) {
@@ -345,23 +350,16 @@ impl Ll1Parser {
     }
 
     fn parse_type_ref(&mut self) -> Result<TypeRef, ParseError> {
-        let name = self.consume_identifier()?;
-        let mut ty = if self.match_kind(&TokenKind::Lt) {
-            let mut args = Vec::new();
-            loop {
-                args.push(self.parse_type_ref()?);
-                if !self.match_kind(&TokenKind::Comma) {
-                    break;
-                }
-            }
-            self.consume(&TokenKind::Gt, "`>` after type arguments")?;
-            TypeRef::with_args(name, args)
-        } else {
-            TypeRef::named(name)
-        };
+        if self.check(&TokenKind::LParen) {
+            return self.parse_function_type_ref();
+        }
+
+        let iterable_prefix = self.match_kind(&TokenKind::Star);
+        let mut ty = self.parse_named_type_ref()?;
 
         loop {
             if self.match_kind(&TokenKind::Star) {
+                // Backwards-compatible spelling from the reference docs: `T*`.
                 ty = TypeRef::with_args("Iterable", vec![ty]);
             } else if self.match_kind(&TokenKind::LBracket) {
                 self.consume(&TokenKind::RBracket, "`]` after vector type suffix")?;
@@ -371,7 +369,56 @@ impl Ll1Parser {
             }
         }
 
+        if iterable_prefix {
+            // Project sugar requested by the user: `*T[]` means an iterable of T.
+            // If the immediate type has just been built as `Vector<T>`, unwrap it
+            // so the semantic type becomes `Iterable<T>`, not `Iterable<Vector<T>>`.
+            ty = match ty {
+                TypeRef { name, mut args } if name == "Vector" && args.len() == 1 => {
+                    TypeRef::with_args("Iterable", vec![args.remove(0)])
+                }
+                other => TypeRef::with_args("Iterable", vec![other]),
+            };
+        }
+
         Ok(ty)
+    }
+
+    fn parse_named_type_ref(&mut self) -> Result<TypeRef, ParseError> {
+        let name = self.consume_identifier()?;
+        if self.match_kind(&TokenKind::Lt) {
+            let mut args = Vec::new();
+            loop {
+                args.push(self.parse_type_ref()?);
+                if !self.match_kind(&TokenKind::Comma) {
+                    break;
+                }
+            }
+            self.consume(&TokenKind::Gt, "`>` after type arguments")?;
+            Ok(TypeRef::with_args(name, args))
+        } else {
+            Ok(TypeRef::named(name))
+        }
+    }
+
+    fn parse_function_type_ref(&mut self) -> Result<TypeRef, ParseError> {
+        self.consume(&TokenKind::LParen, "`(` before function type parameters")?;
+        let mut args = Vec::new();
+
+        if !self.check(&TokenKind::RParen) {
+            loop {
+                args.push(self.parse_type_ref()?);
+                if !self.match_kind(&TokenKind::Comma) {
+                    break;
+                }
+            }
+        }
+
+        self.consume(&TokenKind::RParen, "`)` after function type parameters")?;
+        self.consume(&TokenKind::Arrow, "`->` in function type")?;
+        args.push(self.parse_type_ref()?);
+
+        Ok(TypeRef::with_args("Function", args))
     }
 
     /// Lowest-precedence expression entry point.
@@ -678,6 +725,10 @@ impl Ll1Parser {
             ));
         }
 
+        if self.check(&TokenKind::LParen) && self.lookahead_starts_lambda_expression() {
+            return self.parse_lambda_expression();
+        }
+
         let token = self.advance();
         let span = token_span(token.span);
 
@@ -713,6 +764,24 @@ impl Ll1Parser {
                 span,
             )),
         }
+    }
+
+    fn parse_lambda_expression(&mut self) -> Result<Expr, ParseError> {
+        let paren = self.consume(&TokenKind::LParen, "`(` before lambda parameter list")?;
+        let span = token_span(paren.span);
+        let params = self.parse_param_list_after_lparen()?;
+        let return_type = if self.match_kind(&TokenKind::Colon) {
+            Some(self.parse_type_ref()?)
+        } else {
+            None
+        };
+        self.consume(&TokenKind::FatArrow, "`=>` after lambda parameters")?;
+        let body = self.parse_expression()?;
+
+        Ok(Expr::new(
+            ExprKind::Lambda(LambdaExpr::new(params, return_type, body)),
+            span,
+        ))
     }
 
     fn parse_block_expression(&mut self) -> Result<Expr, ParseError> {
@@ -930,7 +999,88 @@ impl Ll1Parser {
         Ok(expr)
     }
 
-    /// FIRST(Declaration) = { function, type, protocol }.
+    fn lookahead_starts_lambda_expression(&self) -> bool {
+        if !matches!(&self.peek().kind, TokenKind::LParen) {
+            return false;
+        }
+
+        let Some(close_paren) = self.find_matching_paren(self.current) else {
+            return false;
+        };
+
+        let mut cursor = close_paren + 1;
+        if self.token_at(cursor).map(|k| same_variant(k, &TokenKind::Colon)).unwrap_or(false) {
+            cursor += 1;
+            cursor = self.skip_type_ref_tokens(cursor);
+        }
+
+        self.token_at(cursor)
+            .map(|kind| same_variant(kind, &TokenKind::FatArrow))
+            .unwrap_or(false)
+    }
+
+    fn find_matching_paren(&self, start: usize) -> Option<usize> {
+        let mut depth = 0usize;
+        for index in start..self.tokens.len() {
+            match &self.tokens[index].kind {
+                TokenKind::LParen => depth += 1,
+                TokenKind::RParen => {
+                    depth = depth.saturating_sub(1);
+                    if depth == 0 {
+                        return Some(index);
+                    }
+                }
+                TokenKind::Eof => return None,
+                _ => {}
+            }
+        }
+        None
+    }
+
+    fn skip_type_ref_tokens(&self, start: usize) -> usize {
+        let mut index = start;
+        let mut angle_depth = 0usize;
+        let mut paren_depth = 0usize;
+        let mut bracket_depth = 0usize;
+
+        while let Some(kind) = self.token_at(index) {
+            match kind {
+                TokenKind::FatArrow | TokenKind::Eof
+                    if angle_depth == 0 && paren_depth == 0 && bracket_depth == 0 => break,
+                TokenKind::LParen => paren_depth += 1,
+                TokenKind::RParen => {
+                    if paren_depth == 0 && angle_depth == 0 && bracket_depth == 0 {
+                        break;
+                    }
+                    paren_depth = paren_depth.saturating_sub(1);
+                }
+                TokenKind::Lt => angle_depth += 1,
+                TokenKind::Gt => {
+                    if angle_depth == 0 && paren_depth == 0 && bracket_depth == 0 {
+                        break;
+                    }
+                    angle_depth = angle_depth.saturating_sub(1);
+                }
+                TokenKind::LBracket => bracket_depth += 1,
+                TokenKind::RBracket => {
+                    if bracket_depth == 0 && angle_depth == 0 && paren_depth == 0 {
+                        break;
+                    }
+                    bracket_depth = bracket_depth.saturating_sub(1);
+                }
+                _ => {}
+            }
+            index += 1;
+        }
+
+        index
+    }
+
+    fn token_at(&self, index: usize) -> Option<&TokenKind> {
+        self.tokens.get(index).map(|token| &token.kind)
+    }
+
+    /// FIRST(Declaration) = { function, def, type, protocol }.
     fn lookahead_starts_declaration(&self) -> bool {
         matches!(
             &self.peek().kind,
@@ -1128,7 +1278,7 @@ fn token_kind_name(kind: &TokenKind) -> String {
         TokenKind::As => "`as`".to_string(),
         TokenKind::Protocol => "`protocol`".to_string(),
         TokenKind::Extends => "`extends`".to_string(),
-        TokenKind::Def => "`define`".to_string(),
+        TokenKind::Def => "`def`".to_string(),
         TokenKind::Match => "`match`".to_string(),
         TokenKind::Case => "`case`".to_string(),
         TokenKind::Underscore => "`_`".to_string(),
@@ -1281,6 +1431,75 @@ mod tests {
                 ));
             }
             other => panic!("expected let entry, got {other:?}"),
+        }
+    }
+
+
+    #[test]
+    fn parses_lambda_expression() {
+        let program = parse_source("let f = (x: Number): Boolean => { x % 2 == 0; } in f(4);");
+
+        match program.entry.kind {
+            ExprKind::Let(let_expr) => {
+                assert!(matches!(
+                    let_expr.bindings[0].initializer.kind,
+                    ExprKind::Lambda(_)
+                ));
+            }
+            other => panic!("expected let entry, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_function_type_vector_sugar() {
+        let program = parse_source("function apply(xs: Number[], f: (Number[]) -> Boolean): Boolean => f(xs); print(true);");
+
+        match &program.declarations[0].kind {
+            DeclarationKind::Function(function) => {
+                assert_eq!(
+                    function.params[0]
+                        .type_annotation
+                        .as_ref()
+                        .map(ToString::to_string),
+                    Some("Vector<Number>".to_string())
+                );
+                assert_eq!(
+                    function.params[1]
+                        .type_annotation
+                        .as_ref()
+                        .map(ToString::to_string),
+                    Some("(Vector<Number>) -> Boolean".to_string())
+                );
+            }
+            other => panic!("expected function declaration, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_iterable_prefix_vector_sugar() {
+        let program = parse_source("function sum(xs: *Number[]): Number => 0; print(sum([1]));");
+
+        match &program.declarations[0].kind {
+            DeclarationKind::Function(function) => {
+                assert_eq!(
+                    function.params[0]
+                        .type_annotation
+                        .as_ref()
+                        .map(ToString::to_string),
+                    Some("Iterable<Number>".to_string())
+                );
+            }
+            other => panic!("expected function declaration, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_def_as_global_macro_like_function() {
+        let program = parse_source("def twice(x: Number): Number => x * 2; print(twice(21));");
+
+        match &program.declarations[0].kind {
+            DeclarationKind::Function(function) => assert_eq!(function.name, "twice"),
+            other => panic!("expected function declaration, got {other:?}"),
         }
     }
 

--- a/crates/hulk-semantic/src/passes/check.rs
+++ b/crates/hulk-semantic/src/passes/check.rs
@@ -247,6 +247,8 @@ impl<'a> Checker<'a> {
                 }
             }
 
+            ExprKind::Lambda(lambda) => self.check_expr(&lambda.body),
+
             ExprKind::Member(member) => {
                 // Recurse into the object (also checks for Unknown).
                 self.check_expr(&member.object);
@@ -435,6 +437,14 @@ impl<'a> Checker<'a> {
                     match tr.name.as_str() {
                         "Vector" if !args.is_empty() => Type::Vector(Box::new(args[0].clone())),
                         "Iterable" if !args.is_empty() => Type::Iterable(Box::new(args[0].clone())),
+                        "Function" if !args.is_empty() => {
+                            let return_type = args.last().cloned().unwrap_or(Type::Object);
+                            let params = args[..args.len() - 1].to_vec();
+                            Type::Function {
+                                params,
+                                return_type: Box::new(return_type),
+                            }
+                        }
                         _ => Type::Named(tr.name.clone()),
                     }
                 }
@@ -634,6 +644,7 @@ mod tests {
                 ExprKind::For(for_expr) => find_recursive_call(&for_expr.iterable)
                     .or_else(|| find_recursive_call(&for_expr.body)),
                 ExprKind::Member(member) => find_recursive_call(&member.object),
+                ExprKind::Lambda(lambda) => find_recursive_call(&lambda.body),
                 ExprKind::New(new_expr) => {
                     for arg in &new_expr.args {
                         if let Some(found) = find_recursive_call(arg) {

--- a/crates/hulk-semantic/src/passes/collect.rs
+++ b/crates/hulk-semantic/src/passes/collect.rs
@@ -380,6 +380,14 @@ fn resolve_type_ref(tr: &TypeRef) -> Type {
                 match tr.name.as_str() {
                     "Vector" if !args.is_empty() => Type::Vector(Box::new(args[0].clone())),
                     "Iterable" if !args.is_empty() => Type::Iterable(Box::new(args[0].clone())),
+                    "Function" if !args.is_empty() => {
+                        let return_type = args.last().cloned().unwrap_or(Type::Object);
+                        let params = args[..args.len() - 1].to_vec();
+                        Type::Function {
+                            params,
+                            return_type: Box::new(return_type),
+                        }
+                    }
                     // For other named types with arguments (if any), we store the name and
                     // arguments in the `args` field of `TypeRef`, but our `Type` enum does
                     // not support user‑defined generics. We simply treat it as a plain

--- a/crates/hulk-semantic/src/passes/infer.rs
+++ b/crates/hulk-semantic/src/passes/infer.rs
@@ -15,7 +15,7 @@ use std::collections::{HashMap, HashSet};
 use hulk_ast::{
     AssignExpr, AssignTarget, AttributeDecl, BinaryExpr, BinaryOp, BlockExpr, CallExpr,
     Declaration, DeclarationKind, DowncastExpr, ElifBranch, Expr, ExprKind, ForExpr, FunctionDecl,
-    IfExpr, IndexExpr, LetBinding, LetExpr, Literal, MatchCase, MatchExpr, MemberExpr, NewExpr,
+    IfExpr, IndexExpr, LambdaExpr, LetBinding, LetExpr, Literal, MatchCase, MatchExpr, MemberExpr, NewExpr,
     Pattern, Program, SourceSpan, TypeDecl, TypeMember, TypeMemberKind, TypeParent, TypeRef,
     TypeTestExpr, UnaryExpr, UnaryOp, VectorComprehension, VectorExpr, WhileExpr,
 };
@@ -466,6 +466,7 @@ impl<'a> InferState<'a> {
             ExprKind::While(while_expr) => self.infer_while(while_expr, env),
             ExprKind::For(for_expr) => self.infer_for(for_expr, env),
             ExprKind::Call(call) => self.infer_call(call, env),
+            ExprKind::Lambda(lambda) => self.infer_lambda(lambda, span, env),
             ExprKind::Member(member) => self.infer_member(member, env),
             ExprKind::New(new_expr) => self.infer_new(new_expr, span, env),
             ExprKind::TypeTest(type_test) => self.infer_type_test(type_test, span, env),
@@ -487,6 +488,64 @@ impl<'a> InferState<'a> {
             Literal::Boolean(_) => Type::Boolean,
         };
         typed_expr(ExprKind::Literal(lit.clone()), ty, span)
+    }
+
+    // -------------------------------------------------------------------------
+    // Lambda expressions
+    // -------------------------------------------------------------------------
+
+    fn infer_lambda(
+        &mut self,
+        lambda: &LambdaExpr,
+        span: SourceSpan,
+        env: &mut Environment,
+    ) -> TypedExpr {
+        let mut lambda_env = env.clone();
+        lambda_env.push_scope();
+
+        let mut param_types = Vec::new();
+        for param in &lambda.params {
+            let ty = param
+                .type_annotation
+                .as_ref()
+                .map(|tr| self.resolve_type_ref(tr))
+                .unwrap_or(Type::Unknown);
+            lambda_env.declare(&param.name, ty.clone(), span);
+            param_types.push(ty);
+        }
+
+        let typed_body = self.infer_expr(&lambda.body, &mut lambda_env);
+
+        let return_type = if let Some(annotation) = &lambda.return_type {
+            let annotated = self.resolve_type_ref(annotation);
+            if !typed_body.anno.conforms_to(&annotated, self.registry) {
+                self.errors.push(SemanticError::error(
+                    SemanticErrorKind::TypeMismatch {
+                        expected: annotated.clone(),
+                        found: typed_body.anno.clone(),
+                    },
+                    lambda.body.span,
+                ));
+            }
+            annotated
+        } else {
+            typed_body.anno.clone()
+        };
+
+        let lambda_type = Type::Function {
+            params: param_types,
+            return_type: Box::new(return_type),
+        };
+
+        typed_expr(
+            ExprKind::Lambda(LambdaExpr::new(
+                lambda.params.clone(),
+                lambda.return_type.clone(),
+                typed_body,
+            )),
+            lambda_type,
+            span,
+        )
     }
 
     // -------------------------------------------------------------------------
@@ -1820,6 +1879,14 @@ impl<'a> InferState<'a> {
                     match tr.name.as_str() {
                         "Vector" if !args.is_empty() => Type::Vector(Box::new(args[0].clone())),
                         "Iterable" if !args.is_empty() => Type::Iterable(Box::new(args[0].clone())),
+                        "Function" if !args.is_empty() => {
+                            let return_type = args.last().cloned().unwrap_or(Type::Object);
+                            let params = args[..args.len() - 1].to_vec();
+                            Type::Function {
+                                params,
+                                return_type: Box::new(return_type),
+                            }
+                        }
                         _ => Type::Named(tr.name.clone()),
                     }
                 }

--- a/crates/hulk-semantic/src/passes/infer.rs
+++ b/crates/hulk-semantic/src/passes/infer.rs
@@ -15,9 +15,9 @@ use std::collections::{HashMap, HashSet};
 use hulk_ast::{
     AssignExpr, AssignTarget, AttributeDecl, BinaryExpr, BinaryOp, BlockExpr, CallExpr,
     Declaration, DeclarationKind, DowncastExpr, ElifBranch, Expr, ExprKind, ForExpr, FunctionDecl,
-    IfExpr, IndexExpr, LambdaExpr, LetBinding, LetExpr, Literal, MatchCase, MatchExpr, MemberExpr, NewExpr,
-    Pattern, Program, SourceSpan, TypeDecl, TypeMember, TypeMemberKind, TypeParent, TypeRef,
-    TypeTestExpr, UnaryExpr, UnaryOp, VectorComprehension, VectorExpr, WhileExpr,
+    IfExpr, IndexExpr, LambdaExpr, LetBinding, LetExpr, Literal, MatchCase, MatchExpr, MemberExpr,
+    NewExpr, Pattern, Program, SourceSpan, TypeDecl, TypeMember, TypeMemberKind, TypeParent,
+    TypeRef, TypeTestExpr, UnaryExpr, UnaryOp, VectorComprehension, VectorExpr, WhileExpr,
 };
 
 use crate::environment::Environment;

--- a/crates/hulk-semantic/src/passes/infer_utils.rs
+++ b/crates/hulk-semantic/src/passes/infer_utils.rs
@@ -184,6 +184,9 @@ pub fn patch_unknowns(
                 patch_unknowns(arg, param_types, current_function, return_type);
             }
         }
+        ExprKind::Lambda(lambda) => {
+            patch_unknowns(&mut lambda.body, param_types, current_function, return_type);
+        }
         ExprKind::Member(member) => {
             patch_unknowns(
                 &mut member.object,
@@ -310,6 +313,7 @@ pub fn recompute_annotations(expr: &mut TypedExpr, registry: &TypeRegistry) {
                 recompute_annotations(arg, registry);
             }
         }
+        ExprKind::Lambda(lambda) => recompute_annotations(&mut lambda.body, registry),
         ExprKind::Member(member) => recompute_annotations(&mut member.object, registry),
         ExprKind::New(new_expr) => {
             for arg in &mut new_expr.args {
@@ -485,6 +489,15 @@ fn compute_node_type(expr: &TypedExpr, registry: &TypeRegistry) -> Type {
             }
         }
 
+        // ─── Lambda ─────────────────────────────────────────────────────────
+        ExprKind::Lambda(lambda) => match &expr.anno {
+            Type::Function { params, .. } => Type::Function {
+                params: params.clone(),
+                return_type: Box::new(lambda.body.anno.clone()),
+            },
+            other => other.clone(),
+        },
+
         // ─── Member ──────────────────────────────────────────────────────────
         ExprKind::Member(member) => {
             let obj_ty = &member.object.anno;
@@ -595,6 +608,14 @@ fn resolve_type_ref_static(tr: &TypeRef, registry: &TypeRegistry) -> Type {
                 match tr.name.as_str() {
                     "Vector" if !args.is_empty() => Type::Vector(Box::new(args[0].clone())),
                     "Iterable" if !args.is_empty() => Type::Iterable(Box::new(args[0].clone())),
+                    "Function" if !args.is_empty() => {
+                        let return_type = args.last().cloned().unwrap_or(Type::Object);
+                        let params = args[..args.len() - 1].to_vec();
+                        Type::Function {
+                            params,
+                            return_type: Box::new(return_type),
+                        }
+                    }
                     _ => Type::Named(tr.name.clone()),
                 }
             }

--- a/crates/hulk-semantic/src/passes/resolve_constructor_params.rs
+++ b/crates/hulk-semantic/src/passes/resolve_constructor_params.rs
@@ -262,6 +262,7 @@ where
                 traverse_expr(arg, f);
             }
         }
+        ExprKind::Lambda(lambda) => traverse_expr(&lambda.body, f),
         ExprKind::Member(member) => traverse_expr(&member.object, f),
         ExprKind::New(new_expr) => {
             for arg in &new_expr.args {


### PR DESCRIPTION
## Summary
Implements lambda expressions end-to-end: frontend (Juan Carlos) + codegen (Dario).
5/6 lambda tests pass. lambda_compose deferred (requires closure capture).

## Frontend (Juan Carlos, merged from parser-upgrades)
- Lambda syntax: `function (x: Number): T -> expr` as primary expression
- Function type annotations: `(Number) -> String`
- Type sugar: `T[]` = `Vector<T>`, `T*` = `Iterable<T>`
- `def` as alias for `define`

## Codegen (this PR — 2 atomic commits)

### feat(codegen): lower lambda expressions to LLVM functions
- `lower/lambda.rs`: emits lambda as top-level LLVM function
- Signature: `(ptr env_ignored, user_params...) -> ret`
- Returns `{ null_ptr, fn_addr }` fat pointer
- WHY uniform ABI: Rust RFC 1558 pattern — all function values use
  `{ env_ptr, fn_ptr }` regardless of captures

### feat(parser): parse anonymous function expressions
- `parse_anon_function_after_keyword()` accepts `->` and `=>`
- Added `TokenKind::Function` to `lookahead_starts_primary`

## Verification
- 5/6 lambda tests pass locally
- 77/77 required grader tests pass
- 213 unit tests pass, clippy clean

Closes #36