### PR TITLE
Internal errors in boxing and unboxing

### DIFF
--- a/crates/hulk-codegen/src/error.rs
+++ b/crates/hulk-codegen/src/error.rs
@@ -32,6 +32,8 @@ pub enum CodegenErrorKind {
     },
     /// Unsupported language construct encountered (internal).
     Unsupported { construct: String },
+    /// Internal unnidentified compiler error.
+    Internal(String),
 }
 
 // ─── Constructors ─────────────────────────────────────────────────────────
@@ -76,6 +78,13 @@ impl CodegenError {
         }
     }
 
+    pub fn internal(msg: impl Into<String>, span: Option<SourceSpan>) -> Self {
+        Self {
+            kind: CodegenErrorKind::Internal(msg.into()),
+            span: span,
+        }
+    }
+
     pub fn with_span(mut self, span: SourceSpan) -> Self {
         self.span = Some(span);
         self
@@ -115,6 +124,9 @@ impl fmt::Display for CodegenError {
             }
             CodegenErrorKind::Unsupported { construct } => {
                 write!(f, "unsupported construct: {construct}")
+            }
+            CodegenErrorKind::Internal(msg) => {
+                write!(f, "internal compiler error: {msg}")
             }
         }
     }

--- a/crates/hulk-codegen/src/lib.rs
+++ b/crates/hulk-codegen/src/lib.rs
@@ -118,6 +118,7 @@ pub fn compile(
     // Declare downcast check and fail functions (used in type tests and downcasts)
     let _downcast_check = runtime_decls::declare_downcast_check(&codegen);
     let _downcast_fail = runtime_decls::declare_downcast_fail(&codegen);
+    let _internal_error = runtime_decls::declare_internal_error(&codegen);
 
     // Lower the entry expression and capture its value.
     let entry_result = {

--- a/crates/hulk-codegen/src/lower/for_loop.rs
+++ b/crates/hulk-codegen/src/lower/for_loop.rs
@@ -146,12 +146,13 @@ pub fn lower_for<'ctx>(
         .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
     let current_val = lower_method_call_val(ctx, iter_for_current, &iter_ty, "current", iterable_expr.span)?;
 
-    // WHY: hulk_rt_range_current returns f64 directly (never boxed).
-    // hulk_rt_vector_current returns HulkBox* (needs unboxing for primitive elements).
+    // hulk_rt_range_current returns f64 directly (never boxed).
     let unboxed_current = if matches!(&iter_ty, Type::Named(n) if n == "Range") {
         current_val
-    } else {
-        ensure_unboxed(ctx, current_val, &elem_ty)?
+    }
+    // hulk_rt_vector_current returns HulkBox* (needs unboxing for primitive elements).
+    else {
+        ensure_unboxed(ctx, current_val, &elem_ty, Some(iterable_expr.span))?
     };
 
     // Bind the loop variable.

--- a/crates/hulk-codegen/src/lower/index.rs
+++ b/crates/hulk-codegen/src/lower/index.rs
@@ -89,7 +89,7 @@ pub fn lower_index_get<'ctx>(
         .unwrap_basic(); // safe: function returns a pointer
 
     // 5. Unbox if the element type is primitive.
-    let unboxed = ensure_unboxed(ctx, elem_ptr, expr_anno)?;
+    let unboxed = ensure_unboxed(ctx, elem_ptr, expr_anno, Some(span))?;
 
     Ok(unboxed)
 }

--- a/crates/hulk-codegen/src/lower/mod.rs
+++ b/crates/hulk-codegen/src/lower/mod.rs
@@ -278,6 +278,11 @@ mod tests {
     use hulk_lexer::Lexer;
     use hulk_parser::parse;
     use hulk_semantic::analyze;
+    use hulk_ast::{
+        AssignExpr, AssignTarget, BinaryExpr, BinaryOp, BlockExpr, ElifBranch, Expr, ExprKind,
+        IfExpr, IndexExpr, LetBinding, LetExpr, Literal, SourceSpan, UnaryExpr, UnaryOp, WhileExpr, ForExpr,
+        MatchExpr, MatchCase, Pattern, VectorExpr, VectorComprehension, TypeRef,
+    };
     use hulk_semantic::{seeded_registry, Type};
     use inkwell::context::Context;
 
@@ -596,6 +601,27 @@ mod tests {
                 var: var.to_string(),
                 iterable: Box::new(iterable),
             })),
+            anno: ty,
+            span: dummy_span(),
+        }
+    }
+
+    /// Helper: create a typed vector literal.
+    fn vector_lit(items: Vec<Expr<Type>>, ty: Type) -> Expr<Type> {
+        Expr {
+            kind: ExprKind::Vector(VectorExpr::Literal(items)),
+            anno: ty,
+            span: dummy_span(),
+        }
+    }
+
+    /// Helper: create a typed indexing expression.
+    fn index_expr(object: Expr<Type>, index: Expr<Type>, ty: Type) -> Expr<Type> {
+        Expr {
+            kind: ExprKind::Index(IndexExpr {
+                object: Box::new(object),
+                index: Box::new(index),
+            }),
             anno: ty,
             span: dummy_span(),
         }
@@ -1243,6 +1269,20 @@ mod tests {
         assert_ir_contains(&ir, "for_cond:");
         assert_ir_contains(&ir, "call i1 @hulk_rt_vector_next(ptr");
         assert_ir_contains(&ir, "call ptr @hulk_rt_vector_current(ptr");
+        assert_ir_contains(&ir, "call void @hulk_rt_internal_error()");
+    }
+
+    #[test]
+    fn test_vector_index_primitive_null_check() {
+        // let xs = [1,2,3] in xs[0]
+        let xs = vector_lit(vec![num(1.0), num(2.0), num(3.0)], Type::Vector(Box::new(Type::Number)));
+        let body = index_expr(var("xs", Type::Vector(Box::new(Type::Number))), num(0.0), Type::Number);
+        let expr = let_expr(vec![("xs".to_string(), xs)], body, Type::Number);
+        let ir = lower_expr_to_ir(expr);
+        assert_ir_contains(&ir, "call ptr @hulk_rt_vector_get(ptr");
+        assert_ir_contains(&ir, "br i1");
+        assert_ir_contains(&ir, "unbox_null:");
+        assert_ir_contains(&ir, "call void @hulk_rt_internal_error()");
     }
 
     #[test]

--- a/crates/hulk-codegen/src/lower/utils.rs
+++ b/crates/hulk-codegen/src/lower/utils.rs
@@ -471,38 +471,75 @@ pub fn ensure_boxed<'ctx>(
 /// If `ty` is not Number or Boolean, returns the pointer unchanged.
 /// 
 /// # Errors
-/// Returns `CodegenError::Internal` if the pointer is null, indicating 
-/// a compiler bug (e.g., reading from an uninitialized vector slot).
+/// Returns `CodegenError::Internal` for LLVM builder failures.
 pub fn ensure_unboxed<'ctx>(
     ctx: &mut LowerCtx<'_, 'ctx>,
     boxed_ptr: inkwell::values::BasicValueEnum<'ctx>,
     ty: &Type,
     span: Option<SourceSpan>
 ) -> Result<inkwell::values::BasicValueEnum<'ctx>, CodegenError> {
-  
-       // If the static type is already a pointer type, no unboxing needed.
+    // If the static type is already a pointer type, no unboxing needed.
     if !matches!(ty, Type::Number | Type::Boolean) ||
-       // If boxed_ptr is not a ptr, return without unboxing
-       !boxed_ptr.is_pointer_value()
+        // If boxed_ptr is not a ptr, return without unboxing.
+        !boxed_ptr.is_pointer_value()
     {
         return Ok(boxed_ptr);
     }
 
     let ptr = boxed_ptr.into_pointer_value();
 
-    // If the pointer is null, we cannot unbox it.
-    if ptr.is_null() {
-        return Err(CodegenError::internal(
-            "attempted to unbox a null pointer; possibly reading from an uninitialized vector element",
-            span
-        ));
-    }
+    let current_block = ctx
+        .codegen
+        .builder
+        .get_insert_block()
+        .ok_or_else(|| CodegenError::internal("no active insertion block while unboxing", span))?;
+    let parent_fn = current_block
+        .get_parent()
+        .ok_or_else(|| CodegenError::internal("unboxing outside of a function", span))?;
+
+    let null_bb = ctx.codegen.context.append_basic_block(parent_fn, "unbox_null");
+    let cont_bb = ctx.codegen.context.append_basic_block(parent_fn, "unbox_cont");
+    let merge_bb = ctx.codegen.context.append_basic_block(parent_fn, "unbox_merge");
+
+    let result_ty: inkwell::types::BasicTypeEnum<'ctx> = match ty {
+        Type::Number => ctx.codegen.context.f64_type().into(),
+        Type::Boolean => ctx.codegen.context.bool_type().into(),
+        _ => unreachable!(),
+    };
+    let result_alloca = ctx
+        .codegen
+        .builder
+        .build_alloca(result_ty, "unbox_result")
+        .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
+
+    let is_null = ctx
+        .codegen
+        .builder
+        .build_is_null(ptr, "is_null")
+        .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
+    ctx.codegen
+        .builder
+        .build_conditional_branch(is_null, null_bb, cont_bb)
+        .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
+
+    // Null means the runtime handed an uninitialized vector slot or another invalid object reference.
+    ctx.codegen.builder.position_at_end(null_bb);
+    let fail_fn = runtime_decls::ensure_decl(ctx.codegen, "hulk_rt_internal_error")?;
+    ctx.codegen
+        .builder
+        .build_call(fail_fn, &[], "internal_error")
+        .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
+    ctx.codegen
+        .builder
+        .build_unreachable()
+        .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
 
     let i8_type = ctx.codegen.context.i8_type();
     let i64_type = ctx.codegen.context.i64_type();
     let ptr_type = ctx.codegen.context.ptr_type(Default::default());
 
-    // Compute payload address
+    // Compute payload address only on the non-null path.
+    ctx.codegen.builder.position_at_end(cont_bb);
     let payload_ptr_i8 = unsafe {
         ctx.codegen
             .builder
@@ -532,7 +569,10 @@ pub fn ensure_unboxed<'ctx>(
                     "unbox_num",
                 )
                 .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
-            Ok(val)
+            ctx.codegen
+                .builder
+                .build_store(result_alloca, val)
+                .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
         }
         Type::Boolean => {
             let val = ctx
@@ -549,10 +589,25 @@ pub fn ensure_unboxed<'ctx>(
                     "bool_trunc",
                 )
                 .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
-            Ok(truncated.into())
+            ctx.codegen
+                .builder
+                .build_store(result_alloca, truncated)
+                .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
         }
         _ => unreachable!(),
     }
+
+    ctx.codegen
+        .builder
+        .build_unconditional_branch(merge_bb)
+        .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
+
+    ctx.codegen.builder.position_at_end(merge_bb);
+    let result = ctx.codegen
+        .builder
+        .build_load(result_ty, result_alloca, "unbox_result_load")
+        .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
+    Ok(result)
 }
 
 // Returns `true` if the type is a protocol or an Iterable, which are both represented as fat pointers.

--- a/crates/hulk-codegen/src/lower/utils.rs
+++ b/crates/hulk-codegen/src/lower/utils.rs
@@ -2,7 +2,7 @@
 
 use inkwell::FloatPredicate;
 use inkwell::values::BasicValueEnum;
-use hulk_ast::TypeRef;
+use hulk_ast::{TypeRef, SourceSpan};
 use hulk_semantic::{Type, TypeRegistry};
 use hulk_rt::{TAG_BOX, TAG_NUMBER, TAG_BOOLEAN};
 
@@ -414,17 +414,35 @@ pub fn ensure_boxed<'ctx>(
 
 /// Converts a boxed primitive pointer back to a raw value.
 /// If `ty` is not Number or Boolean, returns the pointer unchanged.
+/// 
+/// # Errors
+/// Returns `CodegenError::Internal` if the pointer is null, indicating 
+/// a compiler bug (e.g., reading from an uninitialized vector slot).
 pub fn ensure_unboxed<'ctx>(
     ctx: &mut LowerCtx<'_, 'ctx>,
     boxed_ptr: inkwell::values::BasicValueEnum<'ctx>,
     ty: &Type,
+    span: Option<SourceSpan>
 ) -> Result<inkwell::values::BasicValueEnum<'ctx>, CodegenError> {
-    // If the static type is already a pointer type, no unboxing needed.
-    if !matches!(ty, Type::Number | Type::Boolean) {
+  
+       // If the static type is already a pointer type, no unboxing needed.
+    if !matches!(ty, Type::Number | Type::Boolean) ||
+       // If boxed_ptr is not a ptr, return without unboxing
+       !boxed_ptr.is_pointer_value()
+    {
         return Ok(boxed_ptr);
     }
 
     let ptr = boxed_ptr.into_pointer_value();
+
+    // If the pointer is null, we cannot unbox it.
+    if ptr.is_null() {
+        return Err(CodegenError::internal(
+            "attempted to unbox a null pointer; possibly reading from an uninitialized vector element",
+            span
+        ));
+    }
+
     let i8_type = ctx.codegen.context.i8_type();
     let i64_type = ctx.codegen.context.i64_type();
     let ptr_type = ctx.codegen.context.ptr_type(Default::default());

--- a/crates/hulk-codegen/src/runtime_decls.rs
+++ b/crates/hulk-codegen/src/runtime_decls.rs
@@ -114,6 +114,14 @@ pub fn declare_downcast_fail<'ctx>(ctx: &CodegenCtx<'ctx>) -> FunctionValue<'ctx
         .add_function("hulk_rt_downcast_fail", fn_type, None)
 }
 
+/// Declares `hulk_rt_internal_error() -> !` (noreturn).
+pub fn declare_internal_error<'ctx>(ctx: &CodegenCtx<'ctx>) -> FunctionValue<'ctx> {
+    if let Some(f) = ctx.module.get_function("hulk_rt_internal_error") { return f; }
+    let void_type = ctx.context.void_type();
+    let fn_type = void_type.fn_type(&[], false);
+    ctx.module.add_function("hulk_rt_internal_error", fn_type, None)
+}
+
 // ─── Vector builtin methods ───────────────────────────────────────────────
 
 /// Declares `hulk_rt_vector_new(len: i64) -> ptr`.
@@ -375,6 +383,7 @@ pub fn ensure_decl<'ctx>(
         "hulk_rt_match_fail" => declare_match_fail(ctx),
         "hulk_rt_downcast_check" => declare_downcast_check(ctx),
         "hulk_rt_downcast_fail" => declare_downcast_fail(ctx),
+        "hulk_rt_internal_error" => declare_internal_error(ctx),
         "hulk_rt_string_equals" => declare_string_equals(ctx),
         "hulk_rt_dynamic_vector_new" => declare_dynamic_vector_new(ctx),
         "hulk_rt_dynamic_vector_append" => declare_dynamic_vector_append(ctx),
@@ -428,6 +437,9 @@ pub fn declare_all(ctx: &mut CodegenCtx) {
     let str_eq = declare_string_equals(ctx);
     ctx.functions
         .insert("hulk_rt_string_equals".to_string(), str_eq);
+
+    let internal_error = declare_internal_error(ctx);
+    ctx.functions.insert("hulk_rt_internal_error".to_string(), internal_error);
 
     // ─── Vector builtin methods ───────────────────────────────────────────
 

--- a/crates/hulk-rt/src/lib.rs
+++ b/crates/hulk-rt/src/lib.rs
@@ -826,6 +826,13 @@ pub extern "C" fn hulk_rt_downcast_fail() -> ! {
     std::process::abort();
 }
 
+/// Called when the generated program hits an internal runtime inconsistency; prints an error message and aborts.
+#[no_mangle]
+pub extern "C" fn hulk_rt_internal_error() -> ! {
+    eprintln!("runtime error: internal error");
+    std::process::abort();
+}
+
 /// Called when a non-exhaustive match is encountered; prints an error message and aborts the program.
 #[no_mangle]
 pub extern "C" fn hulk_rt_match_fail() -> ! {


### PR DESCRIPTION
- MODIFY error.rs: Add `CodegenErrorKind::Internal` to represent compiler bugs.

- MODIFY lower/utils.rs: In `ensure_unboxed`, check that the value is a pointer and not null before attempting to read the payload. This prevents segmentation faults when reading from uninitialized vector slots.

- MODIFY lower/for_loop & lower/index: Pass source spans to `ensure_unboxed` from all call sites so that errors can be reported with context.

- MODIFY lower/utils.rs: In ensure_unboxed, emit a runtime null check before unboxing boxed primitives. Null pointers now branch to a noreturn internal-error trap instead of being handled as a compile-time error.

- MODIFY runtime_decls.rs: Add hulk_rt_internal_error as a noreturn runtime declaration and register it in the on-demand and eager declaration paths.

- MODIFY hulk-rt/src/lib.rs: Implement hulk_rt_internal_error() to print a runtime internal error message and abort.

MODIFY hulk-codegen/src/lib.rs: Declare the new internal-error runtime symbol during codegen setup.

MODIFY lower/mod.rs: Add a regression test for primitive vector indexing that verifies the generated IR includes the runtime null-check path.