### PR TITLE
Macros implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "hulk-parser",
  "hulk-rt",
  "hulk-semantic",
+ "hulk-transpile",
  "indexmap",
  "inkwell",
  "tempfile",

--- a/crates/hulk-ast/src/lib.rs
+++ b/crates/hulk-ast/src/lib.rs
@@ -898,6 +898,12 @@ pub enum MacroPattern {
     Wildcard,
     /// Matches a specific literal.
     Literal(Literal),
+    /// Binds the matched sub‑expression to a name, optionally with a type constraint.
+    Bind {
+        name: Option<String>,
+        ty: Option<TypeRef>,
+        pattern: Box<MacroPattern>,
+    },
     /// Matches a binary expression with a specific operator and recursive sub‑patterns.
     BinaryExpr {
         op: BinaryOp,

--- a/crates/hulk-ast/src/lib.rs
+++ b/crates/hulk-ast/src/lib.rs
@@ -373,6 +373,8 @@ pub enum ExprKind<A = ()> {
     Match(MatchExpr<A>),
     /// Macro invocation site — replaced by the expander before semantic analysis.
     MacroCall(MacroCallExpr<A>),
+    /// Compile‑time pattern matching, used only inside macro definitions.
+    MacroMatch(MacroMatchExpr<A>),
 }
 
 /// Literal values.
@@ -885,6 +887,65 @@ impl<A> MacroCallExpr<A> {
     }
 }
 
+// =============================================================================
+// Macro pattern matching
+// =============================================================================
+
+/// A pattern that matches the shape of an AST node during macro expansion.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MacroPattern {
+    /// Matches any expression (wildcard).
+    Wildcard,
+    /// Matches a specific literal.
+    Literal(Literal),
+    /// Matches a binary expression with a specific operator and recursive sub‑patterns.
+    BinaryExpr {
+        op: BinaryOp,
+        left: Box<MacroPatternBind>,
+        right: Box<MacroPatternBind>,
+    },
+    /// Matches a unary expression with a specific operator and a recursive sub‑pattern.
+    UnaryExpr {
+        op: UnaryOp,
+        operand: Box<MacroPatternBind>,
+    },
+    // Future extensions: Call, Member, Let, etc.
+    // Relatively hard for the initial implementation, but could be easily extended later.
+    // The main difficulty would be in addapting the parser grammar without conflicts.
+}
+
+/// A binding site in a macro pattern: captures the matched sub‑expression
+/// under an optional name, optionally with a type constraint.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MacroPatternBind {
+    /// If `Some`, the matched sub‑expression is stored in the substitution map
+    /// under this name, so it can be used in the case body.
+    pub name: Option<String>,
+    /// Optional type annotation (used for consistency checking during expansion).
+    pub ty: Option<TypeRef>,
+    /// The shape this binding must match.
+    pub pattern: MacroPattern,
+}
+
+/// A single case in a `macro match` expression.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MacroCase<A = ()> {
+    pub pattern: MacroPattern,
+    pub body: Expr<A>,
+}
+
+/// A compile‑time `match` expression used inside macro bodies.
+/// The scrutinee is a concrete AST node (already expanded), and the cases
+/// are tested in order; the first matching case provides the substitution map
+/// for expanding its body.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MacroMatchExpr<A = ()> {
+    /// The expression to match against (must be a fully‑expanded AST node).
+    pub scrutinee: Box<Expr<A>>,
+    /// List of cases evaluated in order.
+    pub cases: Vec<MacroCase<A>>,
+}
+
 /// Generic AST visitor.
 ///
 /// This trait is intentionally small. Specific compiler passes can implement
@@ -990,6 +1051,13 @@ where
             }
             if let Some(body) = &mc.body {
                 walk_expr(body, visit);
+            }
+        }
+        ExprKind::MacroMatch(mm) => {
+            // Dereference the box to get &Expr<A>
+            walk_expr(&*mm.scrutinee, visit);
+            for case in &mm.cases {
+                walk_expr(&case.body, visit);
             }
         }
     }

--- a/crates/hulk-codegen/Cargo.toml
+++ b/crates/hulk-codegen/Cargo.toml
@@ -15,4 +15,5 @@ inkwell = { version = "0.8.0", features = ["llvm17-0"] }
 [dev-dependencies]
 hulk-lexer = { path = "../hulk-lexer" }
 hulk-parser = { path = "../hulk-parser" }
+hulk-transpile = { path = "../hulk-transpile" }
 tempfile = "3"

--- a/crates/hulk-codegen/src/itables.rs
+++ b/crates/hulk-codegen/src/itables.rs
@@ -271,6 +271,9 @@ fn collect_used_pairs(program: &Program<Type>, registry: &TypeRegistry) -> HashS
                     mc.name
                 );
             }
+            ExprKind::MacroMatch(_mm) => {
+                panic!("internal error: macro match reached code generation unexpanded");
+            }
         }
     }
 

--- a/crates/hulk-codegen/src/lib.rs
+++ b/crates/hulk-codegen/src/lib.rs
@@ -534,3 +534,152 @@ mod tests {
         assert!(is_elf(&obj));
     }
 }
+
+#[cfg(test)]
+mod macro_tests {
+    use super::*;
+    use hulk_lexer::Lexer;
+    use hulk_parser::parse;
+    use hulk_transpile::expand_program;
+    use hulk_semantic::analyze;
+    use std::process::Command;
+    use tempfile::tempdir;
+
+    fn compile_and_run(src: &str) -> String {
+        let tokens = Lexer::new(src).tokenize().expect("lex failed");
+        let mut program = parse(tokens).expect("parse failed");
+        let macro_errors = expand_program(&mut program);
+        assert!(macro_errors.is_empty(), "macro expansion errors: {:?}", macro_errors);
+        let verified = analyze(&program).expect("semantic analysis failed");
+
+        let temp_dir = tempdir().expect("create temp dir");
+        let output_path = temp_dir.path().join("output");
+        let opts = CodegenOptions::with_output_path(output_path.clone());
+        compile(&verified, &opts).expect("codegen failed");
+
+        let obj_path = output_path.with_extension("o");
+        link_output(&obj_path, &output_path).expect("linking failed");
+
+        let output = Command::new(&output_path)
+            .output()
+            .expect("failed to run executable");
+        assert!(output.status.success(), "executable failed: {}", String::from_utf8_lossy(&output.stderr));
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    #[test]
+    fn repeat_macro_basic() {
+        let src = r#"
+            def repeat(n: Number, *expr: Object): Object =>
+                let total = n in
+                while (total >= 0) {
+                    total := total - 1;
+                    expr;
+                };
+            repeat(3) { print("hi"); }
+        "#;
+        let output = compile_and_run(src);
+        assert_eq!(output, "hi\nhi\nhi\nhi");
+    }
+
+    #[test]
+    fn swap_macro_symbolic() {
+        let src = r#"
+            def swap(@a: Object, @b: Object) {
+                let temp: Object = a in {
+                    a := b;
+                    b := temp;
+                }
+            }
+            let x: Object = 5, y: Object = 10 in {
+                swap(@x, @y);
+                print(x);
+                print(y);
+            }
+        "#;
+        let output = compile_and_run(src);
+        assert_eq!(output, "10\n5");
+    }
+
+    #[test]
+    fn repeat_macro_with_placeholder() {
+        let src = r#"
+            def repeat($iter: Number, n: Number, *expr:Object) {
+                let iter: Number = 0, total:Number = n in {
+                    while (total >= 0) {
+                        total := total - 1;
+                        expr;
+                        iter := iter + 1
+                    };
+                }
+            }
+            repeat(current, 3) {
+                print(current);
+            }
+        "#;
+        let output = compile_and_run(src);
+        assert_eq!(output, "0\n1\n2\n3");
+    }
+
+    #[test]
+    fn simplify_macro_pattern_matching() {
+        let src = r#"
+            def simplify(expr:Number) {
+                match(expr) {
+                    case (x1:Number + x2:Number) => simplify(x1) + simplify(x2);
+                    case (x1:Number + 0) => simplify(x1);
+                    case (x1:Number - x2:Number) => simplify(x1) - simplify(x2);
+                    case (x1:Number - 0) => simplify(x1);
+                    case (x1:Number * x2:Number) => simplify(x1) * simplify(x2);
+                    case (x1:Number * 1) => simplify(x1);
+                    default => expr;
+                };
+            }
+            print(simplify((42+0)*1));
+        "#;
+        let output = compile_and_run(src);
+        assert_eq!(output, "42");
+    }
+
+    #[test]
+    fn simplify_macro_default_branch() {
+        let src = r#"
+            def simplify(expr:Number) {
+                match(expr) {
+                    case (x1:Number + 0) => simplify(x1);
+                    default => expr;
+                };
+            }
+            print(simplify(5));
+        "#;
+        let output = compile_and_run(src);
+        assert_eq!(output, "5");
+    }
+
+    #[test]
+    fn nested_macro_calls() {
+        let src = r#"
+            def repeat(n: Number, *expr: Object): Object =>
+                let total = n in
+                while (total >= 0) {
+                    total := total - 1;
+                    expr;
+                };
+            def repeat_twice(n: Number, *expr: Object): Object =>
+                repeat(n) { repeat(n) { expr; } };
+            repeat_twice(1) { print("x"); }
+        "#;
+        let output = compile_and_run(src);
+        assert_eq!(output, "x\nx\nx\nx");
+    }
+
+    #[test]
+    fn macro_returning_value() {
+        let src = r#"
+            def inc(x: Number): Number => x + 1;
+            print(inc(41));
+        "#;
+        let output = compile_and_run(src);
+        assert_eq!(output, "42");
+    }
+}

--- a/crates/hulk-codegen/src/lib.rs
+++ b/crates/hulk-codegen/src/lib.rs
@@ -24,6 +24,7 @@ pub mod options;
 pub mod runtime_decls;
 
 use std::path::Path;
+use std::path::PathBuf;
 
 use inkwell::context::Context;
 use inkwell::values::FunctionValue;
@@ -31,6 +32,8 @@ use inkwell::values::FunctionValue;
 pub use context::CodegenCtx;
 pub use error::CodegenError;
 pub use options::{CodegenOptions, OptLevel};
+
+const CARGO_MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
 
 /// Declares `hulk_rt_noop` as an external symbol so generated IR can call
 /// it. Stands in for the `runtime_decls` module that later phases will use
@@ -166,7 +169,15 @@ pub fn link_output(
     let cwd = std::env::current_dir()
         .map_err(|e| error::CodegenError::link("cc", None, format!("cannot get cwd: {e}")))?;
 
-    // WHY: the binary may be invoked as target/release/hulk-cli (dev)
+    // Compute the workspace target directory from CARGO_MANIFEST_DIR.
+    let manifest_dir = PathBuf::from(CARGO_MANIFEST_DIR);
+    let workspace_target = manifest_dir
+        .parent()                 // crates/
+        .and_then(|p| p.parent()) // workspace root
+        .map(|root| root.join("target"))
+        .expect("locate workspace target directory");
+
+    // The binary may be invoked as target/release/hulk-cli (dev)
     // or as ./hulk copied to repo root (grader). Probe both.
     let rt_lib_dir = [
         std::env::current_exe()
@@ -174,6 +185,8 @@ pub fn link_output(
             .and_then(|exe| exe.parent().map(|p| p.to_path_buf())),
         Some(cwd.join("target").join("release")),
         Some(cwd.join("target").join("debug")),
+        Some(workspace_target.join("release")),
+        Some(workspace_target.join("debug")),
     ]
     .into_iter()
     .flatten()
@@ -543,7 +556,51 @@ mod macro_tests {
     use hulk_transpile::expand_program;
     use hulk_semantic::analyze;
     use std::process::Command;
+    use std::path::PathBuf;
     use tempfile::tempdir;
+
+    fn ensure_rt_built() {
+        // Locate the workspace target directory.
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let workspace_target = manifest_dir
+            .parent()
+            .and_then(|p| p.parent())
+            .map(|root| root.join("target"))
+            .expect("locate workspace target directory");
+
+        let raw_profile = std::env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());
+
+        let dir_name: &str = match raw_profile.as_str() {
+        "dev" | "test" => "debug",
+        other => other,
+        };
+
+        let cargo_profile: &str = match raw_profile.as_str() {
+            "debug" => "dev",
+            other => other,
+        };
+
+        let rt_lib_path = workspace_target.join(dir_name).join("libhulk_rt.a");
+
+        if rt_lib_path.exists() {
+            return; // Already built.
+        }
+    
+        // Build hulk-rt with the current profile.
+        let status = std::process::Command::new("cargo")
+            .args(["build", "-p", "hulk-rt", "--profile", cargo_profile])
+            .status()
+            .unwrap_or_else(|e| panic!("Failed to invoke cargo to build hulk-rt: {e}"));
+
+        assert!(status.success(), "cargo build -p hulk-rt --profile {cargo_profile} failed");
+
+        // Verify the library now exists.
+        assert!(
+            rt_lib_path.exists(),
+            "hulk-rt built but library not found at {:?}",
+            rt_lib_path
+        );
+    }
 
     fn compile_and_run(src: &str) -> String {
         let tokens = Lexer::new(src).tokenize().expect("lex failed");
@@ -556,6 +613,8 @@ mod macro_tests {
         let output_path = temp_dir.path().join("output");
         let opts = CodegenOptions::with_output_path(output_path.clone());
         compile(&verified, &opts).expect("codegen failed");
+
+        ensure_rt_built();
 
         let obj_path = output_path.with_extension("o");
         link_output(&obj_path, &output_path).expect("linking failed");

--- a/crates/hulk-codegen/src/lower/binding.rs
+++ b/crates/hulk-codegen/src/lower/binding.rs
@@ -13,7 +13,7 @@
 //!   subsequent bindings can refer to earlier ones.
 //! - A plain `Block` does not introduce a new scope (handled in `control.rs`).
 
-use hulk_ast::{AssignExpr, AssignTarget, LetExpr};
+use hulk_ast::{AssignExpr, AssignTarget, LetExpr, ExprKind};
 use hulk_semantic::Type;
 use inkwell::values::BasicValueEnum;
 
@@ -22,6 +22,7 @@ use crate::error::CodegenError;
 use crate::lower::utils::{convert_to_protocol, is_protocol_or_iterable, resolve_type_ref_to_type};
 use crate::lower::LowerCtx;
 use crate::lower::{index, member, variable};
+use crate::lower::utils::{ensure_boxed, is_heap_allocated_type};
 
 /// Lowers a `let` expression with one or more bindings.
 ///
@@ -74,7 +75,24 @@ pub fn lower_let<'ctx>(
             }
         }
 
-        // 4. Declare the variable with the resolved semantic type.
+        // 4. Box primitive if target type is Object.
+        // ensure_boxed is idempotent – it only boxes when necessary.
+        init_val = ensure_boxed(ctx, init_val, init_ty, &declared_ty)?;
+
+        // 5. If the initializer is a variable or member access, retain the value
+        // because it's a borrowed reference, not a newly created one.
+        if is_heap_allocated_type(&declared_ty, ctx.registry) {
+            if matches!(&binding.initializer.kind, ExprKind::Variable(_) | ExprKind::Member(_)) {
+                let retain_fn = ctx.codegen.functions.get("hulk_rt_retain")
+                    .cloned()
+                    .ok_or_else(|| CodegenError::unsupported("hulk_rt_retain not declared", Some(binding.initializer.span)))?;
+                ctx.codegen.builder
+                    .build_call(retain_fn, &[init_val.into()], "retain_let")
+                    .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
+            }
+        }
+
+        // 6. Declare the variable with the resolved semantic type.
         ctx.declare_var(&binding.name, init_val, declared_ty)?;
     }
 

--- a/crates/hulk-codegen/src/lower/lambda.rs
+++ b/crates/hulk-codegen/src/lower/lambda.rs
@@ -419,5 +419,8 @@ fn walk_free_vars<'ctx>(
                 mc.name
             );
         }
+        ExprKind::MacroMatch(_mm) => {
+                panic!("internal error: macro match reached code generation unexpanded");
+            }
     }
 }

--- a/crates/hulk-codegen/src/lower/new.rs
+++ b/crates/hulk-codegen/src/lower/new.rs
@@ -6,7 +6,7 @@ use hulk_semantic::{Type, TypeRegistry};
 
 use super::lower_expr;
 use crate::error::CodegenError;
-use crate::lower::utils::field_indices;
+use crate::lower::utils::{field_indices, ensure_boxed};
 use crate::lower::LowerCtx;
 
 /// Lowers a `new T(args)` expression.
@@ -207,7 +207,9 @@ pub fn lower_new<'ctx>(
         })?;
 
         // 3. Lower the initializer expression.
-        let val = lower_expr(ctx, init_expr)?;
+        let mut val = lower_expr(ctx, init_expr)?;
+        // Box primitive if attribute type is Object.
+        val = ensure_boxed(ctx, val, &init_expr.anno, attr_ty)?;
 
         // 4. Compute the field pointer as an i8*.
         let offset_val = ctx

--- a/crates/hulk-codegen/src/lower/variable.rs
+++ b/crates/hulk-codegen/src/lower/variable.rs
@@ -5,7 +5,7 @@ use inkwell::values::BasicValueEnum;
 use super::lower_expr;
 use crate::error::CodegenError;
 use crate::lower::builtins::lookup_constant;
-use crate::lower::utils::{convert_to_protocol, is_heap_allocated_type};
+use crate::lower::utils::{convert_to_protocol, is_heap_allocated_type, ensure_boxed};
 use crate::lower::LowerCtx;
 
 /// Lowers a variable reference.
@@ -85,7 +85,10 @@ pub fn lower_assign_variable<'ctx>(
         }
     }
 
-    // 4. Load the old value (for release).
+    // 4. Box primitive if target type is Object.
+    stored_val = ensure_boxed(ctx, stored_val, val_ty, &target_ty)?;
+
+    // 5. Load the old value (for release).
     let old_val = ctx
         .codegen
         .builder
@@ -96,7 +99,7 @@ pub fn lower_assign_variable<'ctx>(
         )
         .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
 
-    // 5. If the target type is heap-allocated, release the old value and retain the new.
+    // 6. If the target type is heap-allocated, release the old value and retain the new.
     if is_heap_allocated_type(&target_ty, ctx.registry) {
         let release_fn = ctx
             .codegen
@@ -121,9 +124,9 @@ pub fn lower_assign_variable<'ctx>(
             .map_err(|e| CodegenError::llvm_verification(e.to_string()))?;
     }
 
-    // 6. Store the (possibly converted) value.
+    // 7. Store the (possibly converted) value.
     ctx.store_var(name, stored_val, Some(span))?;
 
-    // 7. The assignment expression returns the stored value.
+    // 8. The assignment expression returns the stored value.
     Ok(stored_val)
 }

--- a/crates/hulk-parser/GRAMMAR_LL1.md
+++ b/crates/hulk-parser/GRAMMAR_LL1.md
@@ -239,6 +239,59 @@ MacroArgList -> MacroArg (',' MacroArg)* | ε
 MacroArg     -> '@' id | Expr
 ```
 
+### Macro pattern matching (inside macro bodies)
+
+Inside a macro body, the `match` keyword is parsed as a compile‑time pattern‑matching
+expression, not as a runtime `MatchExpr`. The syntax is:
+
+```ebnf
+MacroMatch     -> 'match' '(' Expr ')' '{' MacroCase* '}'
+MacroCase      -> 'case' '(' MacroPattern ')' '=>' Expr ';'
+                | 'default' '=>' Expr ';'
+
+The default arm is represented by the identifier default (not a keyword) and is
+only recognised in the arm position. It is parsed as a wildcard pattern.
+
+Macro patterns have a precedence structure that mirrors expression precedence, but
+patterns are not expressions — they describe the shape of an AST node. The pattern 
+grammar is parsed only when in_macro_body is true. In normal code, match continues 
+to be parsed as a runtime MatchExpr.
+
+MacroPattern   -> MacroOr
+MacroOr        -> MacroAnd ('|' MacroAnd)*
+MacroAnd       -> MacroEquality ('&' MacroEquality)*
+MacroEquality  -> MacroComparison (('==' | '!=') MacroComparison)*
+MacroComparison -> MacroConcat (('<' | '<=' | '>' | '>=') MacroConcat)*
+MacroConcat    -> MacroTerm (('@' | '@@') MacroTerm)*
+MacroTerm      -> MacroFactor (('+' | '-') MacroFactor)*
+MacroFactor    -> MacroUnary (('*' | '/' | '%') MacroUnary)*
+MacroUnary     -> ('-' | '!') MacroUnary | MacroPower
+MacroPower     -> MacroPrimary ('^' MacroUnary)?
+MacroPrimary   -> number
+                | string
+                | 'true'
+                | 'false'
+                | '_'                     // wildcard
+                | id MacroPrimaryId       // binding or simple identifier
+                | '(' MacroPattern ')'
+
+MacroPrimaryId -> ':' TypeRef             // type‑annotated wildcard binding
+                | ':' '(' MacroPattern ')' // compound binding: name: (pattern)
+                | ε                        // simple variable binding (no type)
+
+A MacroPrimary that starts with an identifier may be:
+
+- x → binds the matched expression to x (wildcard shape).
+
+- x: Number → binds to x with type constraint.
+
+- x: (pattern) → binds the whole matched expression to x, where the inner
+pattern is the shape that must be satisfied.
+
+The wildcard _ matches any expression without binding it.
+
+
+
 ## Implementation map
 
 | Grammar non-terminal | Rust method |

--- a/crates/hulk-parser/src/lib.rs
+++ b/crates/hulk-parser/src/lib.rs
@@ -21,7 +21,8 @@ use hulk_ast::{
     LetBinding, LetExpr, Literal, MatchCase, MatchExpr, MemberExpr, NewExpr, Param, Pattern,
     Program, ProtocolDecl, ProtocolMethod, SourceSpan, TypeDecl, TypeMember, TypeMemberKind,
     TypeParent, TypeRef, TypeTestExpr, UnaryOp, VectorComprehension, VectorExpr, VectorGenerator, 
-    WhileExpr, MacroArg, MacroCallExpr, MacroDecl, MacroParam, MacroParamKind,
+    WhileExpr, MacroArg, MacroCallExpr, MacroDecl, MacroParam, MacroParamKind, MacroCase, MacroMatchExpr,
+    MacroPattern, MacroPatternBind,
 };
 use hulk_lexer::{Span, Token, TokenKind};
 
@@ -102,6 +103,9 @@ pub enum ParseErrorKind {
 pub struct Ll1Parser {
     tokens: Vec<Token>,
     current: usize,
+    /// Whether a macro definition body is currently being paarsed.
+    /// This affects how `match` expressions are parsed.
+    in_macro_body: bool,
 }
 
 impl Ll1Parser {
@@ -119,7 +123,7 @@ impl Ll1Parser {
             });
         }
 
-        Self { tokens, current: 0 }
+        Self { tokens, current: 0, in_macro_body: false }
     }
 
     /// Parses a full HULK program: zero or more declarations followed by the
@@ -221,6 +225,10 @@ impl Ll1Parser {
             None
         };
 
+        // ── Enter macro body context ──
+        let old_in_macro = self.in_macro_body;
+        self.in_macro_body = true;
+
         let body = if self.match_kind(&TokenKind::FatArrow) || self.match_kind(&TokenKind::Arrow) {
             let expr = self.parse_expression()?;
             self.match_kind(&TokenKind::Semicolon);
@@ -235,6 +243,9 @@ impl Ll1Parser {
                 self.peek_span(),
             ));
         };
+
+        // ── Restore context ──
+        self.in_macro_body = old_in_macro;
 
         Ok(MacroDecl::new(name, params, return_type, body))
     }
@@ -907,8 +918,8 @@ impl Ll1Parser {
             TokenKind::False => Ok(Expr::boolean(false, span)),
             TokenKind::Ident(name) => Ok(Expr::variable(name, span)),
             TokenKind::SelfKw => Ok(Expr::new(ExprKind::SelfRef, span)),
-            // WHY: `base` is a symbol (§A.7.4), not a keyword — it can be shadowed by a
-            // variable (like `let base: Printer = ...`). Emit Variable("base") here;
+            // `base` is a symbol, not a keyword — it can be shadowed by a variable 
+            // (like `let base: Printer = ...`). Emit Variable("base") here;
             // parse_postfix promotes it to BaseRef only when immediately followed by `(`
             // (the method-delegation call site).
             TokenKind::Base => Ok(Expr::variable("base".to_string(), span)),
@@ -924,7 +935,13 @@ impl Ll1Parser {
             TokenKind::While => self.finish_while_expression(span),
             TokenKind::For => self.finish_for_expression(span),
             TokenKind::New => self.finish_new_expression(span),
-            TokenKind::Match => self.finish_match_expression(span),
+            TokenKind::Match => {
+                if self.in_macro_body {
+                    self.parse_macro_match_expr(span)
+                } else {
+                    self.finish_match_expression(span)
+                }
+            }
             TokenKind::Function => self.parse_anon_function_after_keyword(span),
             other => Err(ParseError::new(
                 ParseErrorKind::ExpectedExpression {
@@ -1258,6 +1275,379 @@ impl Ll1Parser {
                     token_kind_name(&other)
                 )),
                 token_span(token.span),
+            )),
+        }
+    }
+
+    /// Parses a compile‑time `match` expression inside a macro body.
+    /// Syntax: `match ( <expr> ) { case ( <pattern> ) => <expr> ; ... [default => <expr> ;] }`
+    fn parse_macro_match_expr(&mut self, span: SourceSpan) -> Result<Expr, ParseError> {
+        self.consume(&TokenKind::LParen, "`(` after `match`")?;
+        let scrutinee = self.parse_expression()?;
+        self.consume(&TokenKind::RParen, "`)` after scrutinee")?;
+
+        self.consume(&TokenKind::LBrace, "`{` before macro match cases")?;
+
+        let mut cases = Vec::new();
+        let mut has_default = false;
+
+        while !self.check(&TokenKind::RBrace) && !self.is_at_end() {
+            // Contextual `default` arm: an identifier named "default" at arm level.
+            if let TokenKind::Ident(ref name) = &self.peek().kind {
+                if name == "default" && !has_default {
+                    self.advance(); // consume `default`
+                    has_default = true;
+                    self.consume(&TokenKind::FatArrow, "`=>` after `default`")?;
+                    let body = self.parse_expression()?;
+                    self.match_kind(&TokenKind::Semicolon);
+                    cases.push(MacroCase {
+                        pattern: MacroPattern::Wildcard,
+                        body,
+                    });
+                    continue;
+                }
+            }
+
+            // Regular case arm: `case ( <pattern> ) => <expr> ;`
+            self.consume(&TokenKind::Case, "`case` in macro match")?;
+            self.consume(&TokenKind::LParen, "`(` before macro pattern")?;
+            let pattern = self.parse_macro_pattern_or()?; // Parses a compile‑time pattern with precedence.
+            self.consume(&TokenKind::RParen, "`)` after macro pattern")?;
+            self.consume(&TokenKind::FatArrow, "`=>` after macro pattern")?;
+            let body = self.parse_expression()?;
+            self.match_kind(&TokenKind::Semicolon);
+
+            cases.push(MacroCase { pattern, body });
+        }
+
+        self.consume(&TokenKind::RBrace, "`}` after macro match cases")?;
+
+        let macro_match = MacroMatchExpr {
+            scrutinee: Box::new(scrutinee),
+            cases,
+        };
+        Ok(Expr::new(ExprKind::MacroMatch(macro_match), span))
+    }
+
+    // ─── Precedence levels ──────────────────────────────────────────────
+
+    /// Parses `|` (logical or) with left associativity.
+    fn parse_macro_pattern_or(&mut self) -> Result<MacroPattern, ParseError> {
+        let mut left = self.parse_macro_pattern_and()?;
+        while self.match_kind(&TokenKind::Or) {
+            let right = self.parse_macro_pattern_and()?;
+            left = MacroPattern::BinaryExpr {
+                op: BinaryOp::Or,
+                left: Box::new(MacroPatternBind {
+                    name: None,
+                    ty: None,
+                    pattern: left,
+                }),
+                right: Box::new(MacroPatternBind {
+                    name: None,
+                    ty: None,
+                    pattern: right,
+                }),
+            };
+        }
+        Ok(left)
+    }
+
+    /// Parses `&` (logical and) with left associativity.
+    fn parse_macro_pattern_and(&mut self) -> Result<MacroPattern, ParseError> {
+        let mut left = self.parse_macro_pattern_equality()?;
+        while self.match_kind(&TokenKind::And) {
+            let right = self.parse_macro_pattern_equality()?;
+            left = MacroPattern::BinaryExpr {
+                op: BinaryOp::And,
+                left: Box::new(MacroPatternBind {
+                    name: None,
+                    ty: None,
+                    pattern: left,
+                }),
+                right: Box::new(MacroPatternBind {
+                    name: None,
+                    ty: None,
+                    pattern: right,
+                }),
+            };
+        }
+        Ok(left)
+    }
+
+    /// Parses `==` and `!=` with left associativity.
+    fn parse_macro_pattern_equality(&mut self) -> Result<MacroPattern, ParseError> {
+        let mut left = self.parse_macro_pattern_comparison()?;
+        loop {
+            let op = if self.match_kind(&TokenKind::EqEq) {
+                Some(BinaryOp::Equal)
+            } else if self.match_kind(&TokenKind::Neq) {
+                Some(BinaryOp::NotEqual)
+            } else {
+                None
+            };
+            if let Some(op) = op {
+                let right = self.parse_macro_pattern_comparison()?;
+                left = MacroPattern::BinaryExpr {
+                    op,
+                    left: Box::new(MacroPatternBind {
+                        name: None,
+                        ty: None,
+                        pattern: left,
+                    }),
+                    right: Box::new(MacroPatternBind {
+                        name: None,
+                        ty: None,
+                        pattern: right,
+                    }),
+                };
+            } else {
+                break;
+            }
+        }
+        Ok(left)
+    }
+
+    /// Parses `<`, `<=`, `>`, `>=` with left associativity.
+    fn parse_macro_pattern_comparison(&mut self) -> Result<MacroPattern, ParseError> {
+        let mut left = self.parse_macro_pattern_concat()?;
+        loop {
+            let op = if self.match_kind(&TokenKind::Lt) {
+                Some(BinaryOp::Less)
+            } else if self.match_kind(&TokenKind::Leq) {
+                Some(BinaryOp::LessEqual)
+            } else if self.match_kind(&TokenKind::Gt) {
+                Some(BinaryOp::Greater)
+            } else if self.match_kind(&TokenKind::Geq) {
+                Some(BinaryOp::GreaterEqual)
+            } else {
+                None
+            };
+            if let Some(op) = op {
+                let right = self.parse_macro_pattern_concat()?;
+                left = MacroPattern::BinaryExpr {
+                    op,
+                    left: Box::new(MacroPatternBind {
+                        name: None,
+                        ty: None,
+                        pattern: left,
+                    }),
+                    right: Box::new(MacroPatternBind {
+                        name: None,
+                        ty: None,
+                        pattern: right,
+                    }),
+                };
+            } else {
+                break;
+            }
+        }
+        Ok(left)
+    }
+
+    /// Parses `@` and `@@` (string concatenation) with left associativity.
+    fn parse_macro_pattern_concat(&mut self) -> Result<MacroPattern, ParseError> {
+        let mut left = self.parse_macro_pattern_term()?;
+        loop {
+            let op = if self.match_kind(&TokenKind::At) {
+                Some(BinaryOp::Concat)
+            } else if self.match_kind(&TokenKind::AtAt) {
+                Some(BinaryOp::ConcatSpace)
+            } else {
+                None
+            };
+            if let Some(op) = op {
+                let right = self.parse_macro_pattern_term()?;
+                left = MacroPattern::BinaryExpr {
+                    op,
+                    left: Box::new(MacroPatternBind {
+                        name: None,
+                        ty: None,
+                        pattern: left,
+                    }),
+                    right: Box::new(MacroPatternBind {
+                        name: None,
+                        ty: None,
+                        pattern: right,
+                    }),
+                };
+            } else {
+                break;
+            }
+        }
+        Ok(left)
+    }
+
+    /// Parses `+` and `-` with left associativity.
+    fn parse_macro_pattern_term(&mut self) -> Result<MacroPattern, ParseError> {
+        let mut left = self.parse_macro_pattern_factor()?;
+        loop {
+            let op = if self.match_kind(&TokenKind::Plus) {
+                Some(BinaryOp::Add)
+            } else if self.match_kind(&TokenKind::Minus) {
+                Some(BinaryOp::Subtract)
+            } else {
+                None
+            };
+            if let Some(op) = op {
+                let right = self.parse_macro_pattern_factor()?;
+                left = MacroPattern::BinaryExpr {
+                    op,
+                    left: Box::new(MacroPatternBind {
+                        name: None,
+                        ty: None,
+                        pattern: left,
+                    }),
+                    right: Box::new(MacroPatternBind {
+                        name: None,
+                        ty: None,
+                        pattern: right,
+                    }),
+                };
+            } else {
+                break;
+            }
+        }
+        Ok(left)
+    }
+
+    /// Parses `*`, `/`, and `%` with left associativity.
+    fn parse_macro_pattern_factor(&mut self) -> Result<MacroPattern, ParseError> {
+        let mut left = self.parse_macro_pattern_unary()?;
+        loop {
+            let op = if self.match_kind(&TokenKind::Star) {
+                Some(BinaryOp::Multiply)
+            } else if self.match_kind(&TokenKind::Slash) {
+                Some(BinaryOp::Divide)
+            } else if self.match_kind(&TokenKind::Percent) {
+                Some(BinaryOp::Modulo)
+            } else {
+                None
+            };
+            if let Some(op) = op {
+                let right = self.parse_macro_pattern_unary()?;
+                left = MacroPattern::BinaryExpr {
+                    op,
+                    left: Box::new(MacroPatternBind {
+                        name: None,
+                        ty: None,
+                        pattern: left,
+                    }),
+                    right: Box::new(MacroPatternBind {
+                        name: None,
+                        ty: None,
+                        pattern: right,
+                    }),
+                };
+            } else {
+                break;
+            }
+        }
+        Ok(left)
+    }
+
+    /// Parses unary `-` and `!` with right associativity.
+    fn parse_macro_pattern_unary(&mut self) -> Result<MacroPattern, ParseError> {
+        if self.match_kind(&TokenKind::Minus) {
+            let operand = self.parse_macro_pattern_unary()?;
+            return Ok(MacroPattern::UnaryExpr {
+                op: UnaryOp::Negate,
+                operand: Box::new(MacroPatternBind {
+                    name: None,
+                    ty: None,
+                    pattern: operand,
+                }),
+            });
+        }
+        if self.match_kind(&TokenKind::Not) {
+            let operand = self.parse_macro_pattern_unary()?;
+            return Ok(MacroPattern::UnaryExpr {
+                op: UnaryOp::Not,
+                operand: Box::new(MacroPatternBind {
+                    name: None,
+                    ty: None,
+                    pattern: operand,
+                }),
+            });
+        }
+        self.parse_macro_pattern_power()
+    }
+
+    /// Parses `^` (power) with right associativity.
+    fn parse_macro_pattern_power(&mut self) -> Result<MacroPattern, ParseError> {
+        let left = self.parse_macro_pattern_primary()?;
+        if self.match_kind(&TokenKind::Caret) {
+            let right = self.parse_macro_pattern_unary()?;
+            Ok(MacroPattern::BinaryExpr {
+                op: BinaryOp::Power,
+                left: Box::new(MacroPatternBind {
+                    name: None,
+                    ty: None,
+                    pattern: left,
+                }),
+                right: Box::new(MacroPatternBind {
+                    name: None,
+                    ty: None,
+                    pattern: right,
+                }),
+            })
+        } else {
+            Ok(left)
+        }
+    }
+
+    /// Primary pattern: literal, identifier (with optional type), or parenthesised.
+    fn parse_macro_pattern_primary(&mut self) -> Result<MacroPattern, ParseError> {
+        let token = self.advance();
+        let span = token_span(token.span);
+
+        match token.kind {
+            TokenKind::Number(value) => Ok(MacroPattern::Literal(Literal::Number(value))),
+            TokenKind::StringLit(value) => Ok(MacroPattern::Literal(Literal::String(value))),
+            TokenKind::True => Ok(MacroPattern::Literal(Literal::Boolean(true))),
+            TokenKind::False => Ok(MacroPattern::Literal(Literal::Boolean(false))),
+            TokenKind::Underscore => Ok(MacroPattern::Wildcard),
+            
+            TokenKind::Ident(name) => {
+                // Check for a colon after the identifier
+                if self.match_kind(&TokenKind::Colon) {
+                    // Distinguish between type annotation and compound binding.
+                    if self.check(&TokenKind::LParen) {
+                        // `name: (pattern)` – bind the compound pattern
+                        let inner = self.parse_macro_pattern_or()?;
+                        Ok(MacroPattern::Bind {
+                            name: Some(name),
+                            ty: None,
+                            pattern: Box::new(inner),
+                        })
+                    } else {
+                        // `name: Type` – type-annotated wildcard binding
+                        let ty = self.parse_type_ref()?;
+                        Ok(MacroPattern::Bind {
+                            name: Some(name),
+                            ty: Some(ty),
+                            pattern: Box::new(MacroPattern::Wildcard),
+                        })
+                    }
+                } else {
+                    // Simple variable binding (no type annotation)
+                    Ok(MacroPattern::Bind {
+                        name: Some(name),
+                        ty: None,
+                        pattern: Box::new(MacroPattern::Wildcard),
+                    })
+                }
+            }
+
+            TokenKind::LParen => {
+                let inner = self.parse_macro_pattern_or()?;
+                self.consume(&TokenKind::RParen, "`)` after parenthesised pattern")?;
+                Ok(inner)
+            }
+
+            other => Err(ParseError::new(
+                ParseErrorKind::Message(format!("unexpected token in macro pattern: {}", token_kind_name(&other))),
+                span,
             )),
         }
     }

--- a/crates/hulk-parser/src/lib.rs
+++ b/crates/hulk-parser/src/lib.rs
@@ -1483,30 +1483,18 @@ impl Ll1Parser {
         let mut left = self.parse_macro_pattern_factor()?;
         loop {
             let op = if self.match_kind(&TokenKind::Plus) {
-                Some(BinaryOp::Add)
+                BinaryOp::Add
             } else if self.match_kind(&TokenKind::Minus) {
-                Some(BinaryOp::Subtract)
-            } else {
-                None
-            };
-            if let Some(op) = op {
-                let right = self.parse_macro_pattern_factor()?;
-                left = MacroPattern::BinaryExpr {
-                    op,
-                    left: Box::new(MacroPatternBind {
-                        name: None,
-                        ty: None,
-                        pattern: left,
-                    }),
-                    right: Box::new(MacroPatternBind {
-                        name: None,
-                        ty: None,
-                        pattern: right,
-                    }),
-                };
+                BinaryOp::Subtract
             } else {
                 break;
-            }
+            };
+            let right = self.parse_macro_pattern_factor()?;
+            left = MacroPattern::BinaryExpr {
+                op,
+                left: Box::new(MacroPatternBind { name: None, ty: None, pattern: left }),
+                right: Box::new(MacroPatternBind { name: None, ty: None, pattern: right }),
+            };
         }
         Ok(left)
     }
@@ -1622,7 +1610,7 @@ impl Ll1Parser {
                         })
                     } else {
                         // `name: Type` – type-annotated wildcard binding
-                        let ty = self.parse_type_ref()?;
+                        let ty = self.parse_named_type_ref()?;
                         Ok(MacroPattern::Bind {
                             name: Some(name),
                             ty: Some(ty),

--- a/crates/hulk-semantic/src/passes/check.rs
+++ b/crates/hulk-semantic/src/passes/check.rs
@@ -345,6 +345,16 @@ impl<'a> Checker<'a> {
                 ));
                 // Do not recurse into arguments or body – they are invalid at this stage.
             }
+            ExprKind::MacroMatch(_mm) => {
+                // Should never be reached if hulk-transpile ran before the semantic pass.
+                self.errors.push(SemanticError::error(
+                    SemanticErrorKind::MacroReferenceFound {
+                        macro_expr: "Match expression".to_string(),
+                    },
+                    expr.span,
+                ));
+                // Do not recurse into arguments or body – they are invalid at this stage.
+            }
         }
     }
 

--- a/crates/hulk-semantic/src/passes/infer.rs
+++ b/crates/hulk-semantic/src/passes/infer.rs
@@ -18,7 +18,7 @@ use hulk_ast::{
     IfExpr, IndexExpr, LambdaExpr, LetBinding, LetExpr, Literal, MatchCase, MatchExpr, MemberExpr,
     NewExpr, Pattern, Program, SourceSpan, TypeDecl, TypeMember, TypeMemberKind, TypeParent,
     TypeRef, TypeTestExpr, UnaryExpr, UnaryOp, VectorComprehension, VectorExpr, VectorGenerator, 
-    WhileExpr, MacroArg, MacroDecl, MacroCallExpr,
+    WhileExpr, MacroArg, MacroDecl, MacroCallExpr, MacroMatchExpr
 };
 
 use crate::environment::Environment;
@@ -524,6 +524,26 @@ impl<'a> InferState<'a> {
                 };
 
                 typed_expr(ExprKind::MacroCall(mc_typed), Type::Error, expr.span)
+            }
+            ExprKind::MacroMatch(_mm) => {
+                self.errors.push(SemanticError::error(
+                    SemanticErrorKind::MacroReferenceFound {
+                        macro_expr: "macro match".to_string(),
+                    },
+                    expr.span,
+                ));
+
+                // Return a dummy MacroMatchExpr annotated with Error to satisfy the type system.
+                let dummy_scrutinee = Expr {
+                    kind: ExprKind::Variable("".to_string()),
+                    anno: Type::Error,
+                    span: expr.span,
+                };
+                let macro_match = MacroMatchExpr {
+                    scrutinee: Box::new(dummy_scrutinee),
+                    cases: Vec::new(),
+                };
+                typed_expr(ExprKind::MacroMatch(macro_match), Type::Error, expr.span)
             }
         }
     }

--- a/crates/hulk-semantic/src/passes/infer_utils.rs
+++ b/crates/hulk-semantic/src/passes/infer_utils.rs
@@ -550,10 +550,10 @@ fn compute_node_type(expr: &TypedExpr, registry: &TypeRegistry) -> Type {
         // ─── Assignment ─────────────────────────────────────────────────────
         ExprKind::Assign(assign) => assign.value.anno.clone(),
 
-        // ─── Macro call ──────────────────────────────────────────────────────────
-        // Macro calls should be eliminated by the expander before semantic analysis.
-        // If one reaches this point, it's a pipeline error; we return Error.
-        ExprKind::MacroCall(_) => Type::Error,
+        // ─── Macro ──────────────────────────────────────────────────────────
+        // Macro calls and matches should be eliminated by the expander before semantic
+        // analysis. If one reaches this point, it's a pipeline error; we return Error.
+        ExprKind::MacroCall(_) | ExprKind::MacroMatch(_) => Type::Error,
     }
 }
 

--- a/crates/hulk-semantic/src/passes/resolve_constructor_params.rs
+++ b/crates/hulk-semantic/src/passes/resolve_constructor_params.rs
@@ -324,6 +324,18 @@ where
                 traverse_expr(body, errors, f);
             }
         }
+        ExprKind::MacroMatch(mm) => {
+            errors.push(SemanticError::error(
+                SemanticErrorKind::MacroReferenceFound {
+                    macro_expr: "macro match".to_string(),
+                },
+                expr.span,
+            ));
+            traverse_expr(&mm.scrutinee, errors, f);
+            for case in &mm.cases {
+                traverse_expr(&case.body, errors, f);
+            }
+        }
     }
 }
 

--- a/crates/hulk-transpile/src/error.rs
+++ b/crates/hulk-transpile/src/error.rs
@@ -45,6 +45,8 @@ pub enum MacroErrorKind {
     MacroArgInNonMacroCall { name: String },
     /// No case matched in the structure.
     NonExhaustiveMacroMatch,
+    /// A pattern binding is duplicated.
+    DuplicatePatternBinding { name: String },
 }
 
 impl fmt::Display for MacroErrorKind {
@@ -61,6 +63,8 @@ impl fmt::Display for MacroErrorKind {
                 write!(f, "`@{}` or placeholder argument used in a non-macro call", name),
             Self::NonExhaustiveMacroMatch  => 
                 write!(f, "non-exhaustive macro match"),
+            Self::DuplicatePatternBinding { name } =>
+                write!(f, "pattern binding `{}` is duplicated", name),
         }
     }
 }

--- a/crates/hulk-transpile/src/error.rs
+++ b/crates/hulk-transpile/src/error.rs
@@ -43,6 +43,8 @@ pub enum MacroErrorKind {
     MissingBodyBlock(String),
     /// A regular call was given a `@sym` or `$ph` arg without a matching param.
     MacroArgInNonMacroCall { name: String },
+    /// No case matched in the structure.
+    NonExhaustiveMacroMatch,
 }
 
 impl fmt::Display for MacroErrorKind {
@@ -57,6 +59,8 @@ impl fmt::Display for MacroErrorKind {
             Self::MissingBodyBlock(n) => write!(f, "macro `{}` requires a trailing `{{ }}` block", n),
             Self::MacroArgInNonMacroCall { name } =>
                 write!(f, "`@{}` or placeholder argument used in a non-macro call", name),
+            Self::NonExhaustiveMacroMatch  => 
+                write!(f, "non-exhaustive macro match"),
         }
     }
 }

--- a/crates/hulk-transpile/src/expand.rs
+++ b/crates/hulk-transpile/src/expand.rs
@@ -8,7 +8,7 @@
 use std::collections::HashSet;
 use hulk_ast::{
     DeclarationKind, Expr, ExprKind, MacroArg, MacroCallExpr,
-    MacroParam, MacroParamKind, Program, TypeMemberKind,
+    MacroParam, MacroParamKind, Program, TypeMemberKind, MacroMatchExpr,
 };
 
 use crate::collect::MacroRegistry;
@@ -128,6 +128,39 @@ fn expand_expr(
             }
             // Not a macro call -> recursively expand children and keep as Call
             rebuild_expr_children(expr, registry, errors, depth)
+        }
+        ExprKind::MacroMatch(mm) => {
+            // Fully expand the scrutinee first.
+            let scrutinee = expand_expr(*mm.scrutinee, registry, errors, depth);
+
+            // For each case, try to match the pattern against the scrutinee.
+            for case in &mm.cases {
+                if let Some(bindings) = crate::pattern::try_match(&case.pattern, &scrutinee) {
+                    // Build a substitution map from the bindings.
+                    let mut subst = SubstMap::new();
+                    for (name, expr) in bindings {
+                        subst.insert_expr(name, expr);
+                    }
+                    // Expand the case body with the bindings substituted.
+                    let body = substitute(&case.body, &subst);
+                    // Expand the body recursively (it may contain further macro calls).
+                    return expand_expr(body, registry, errors, depth + 1);
+                }
+            }
+
+            // No case matched – this is a runtime error in the macro expansion.
+            // In HULK, a non‑exhaustive macro match is an error.
+            errors.push(MacroError::new(
+                MacroErrorKind::NonExhaustiveMacroMatch,
+                expr.span,
+            ));
+
+            let cases = mm.cases.clone();
+            let new_mm = MacroMatchExpr {
+                scrutinee: Box::new(scrutinee),
+                cases,
+            };
+            Expr::new(ExprKind::MacroMatch(new_mm), expr.span)
         }
         // For all other expression kinds, recursively expand children.
         _ => rebuild_expr_children(expr, registry, errors, depth),

--- a/crates/hulk-transpile/src/expand.rs
+++ b/crates/hulk-transpile/src/expand.rs
@@ -14,6 +14,7 @@ use hulk_ast::{
 use crate::collect::MacroRegistry;
 use crate::error::{MacroError, MacroErrorKind};
 use crate::substitute::{collect_let_bindings, substitute, SubstMap};
+use crate::pattern::try_match;
 
 /// Hard-coded expansion passes limit
 const MAX_EXPANSION_PASSES: usize = 64;
@@ -129,36 +130,42 @@ fn expand_expr(
             // Not a macro call -> recursively expand children and keep as Call
             rebuild_expr_children(expr, registry, errors, depth)
         }
-        ExprKind::MacroMatch(mm) => {
-            // Fully expand the scrutinee first.
-            let scrutinee = expand_expr(*mm.scrutinee, registry, errors, depth);
+       ExprKind::MacroMatch(mm) => {
+            // Clone the scrutinee to avoid moving out of mm.
+            let scrutinee = expand_expr((*mm.scrutinee).clone(), registry, errors, depth);
 
-            // For each case, try to match the pattern against the scrutinee.
+            // Try each case in order.
             for case in &mm.cases {
-                if let Some(bindings) = crate::pattern::try_match(&case.pattern, &scrutinee) {
-                    // Build a substitution map from the bindings.
-                    let mut subst = SubstMap::new();
-                    for (name, expr) in bindings {
-                        subst.insert_expr(name, expr);
+                match try_match(&case.pattern, &scrutinee) {
+                    Ok(Some(bindings)) => {
+                        let mut subst = SubstMap::new();
+                        for (name, expr) in bindings {
+                            subst.insert_expr(name, expr);
+                        }
+                        let body = substitute(&case.body, &subst);
+                        return expand_expr(body, registry, errors, depth + 1);
                     }
-                    // Expand the case body with the bindings substituted.
-                    let body = substitute(&case.body, &subst);
-                    // Expand the body recursively (it may contain further macro calls).
-                    return expand_expr(body, registry, errors, depth + 1);
+                    Ok(None) => continue,
+                    Err(err_kind) => {
+                        errors.push(MacroError::new(err_kind, expr.span));
+                        // Return the expanded expression with the error.
+                        let new_mm = MacroMatchExpr {
+                            scrutinee: Box::new(scrutinee),
+                            cases: mm.cases.clone(),
+                        };
+                        return Expr::new(ExprKind::MacroMatch(new_mm), expr.span);
+                    }
                 }
             }
 
-            // No case matched – this is a runtime error in the macro expansion.
-            // In HULK, a non‑exhaustive macro match is an error.
+            // No case matched – report error and return the expanded expression.
             errors.push(MacroError::new(
                 MacroErrorKind::NonExhaustiveMacroMatch,
                 expr.span,
             ));
-
-            let cases = mm.cases.clone();
             let new_mm = MacroMatchExpr {
                 scrutinee: Box::new(scrutinee),
-                cases,
+                cases: mm.cases.clone(),
             };
             Expr::new(ExprKind::MacroMatch(new_mm), expr.span)
         }

--- a/crates/hulk-transpile/src/pattern.rs
+++ b/crates/hulk-transpile/src/pattern.rs
@@ -12,13 +12,15 @@ use std::collections::HashMap;
 use hulk_ast::{
     Expr, ExprKind, MacroPattern, MacroPatternBind,
 };
+use crate::error::MacroErrorKind;
 
 /// Attempts to match a `pattern` against the concrete AST node `expr`.
 ///
 /// # Returns
-/// - `Some(bindings)` if the pattern matches, where `bindings` maps each
+/// - `Ok(Some(bindings))` if the pattern matches, where `bindings` maps each
 ///   capture variable name to the `Expr` subtree that was matched.
-/// - `None` if the pattern does not match.
+/// - `Ok(None)` if the pattern does not match (shape mismatch).
+/// - `Err(MacroErrorKind)` if a structural error occurs, e.g., duplicate bindings.
 ///
 /// # Matching rules
 /// - `MacroPattern::Wildcard` always matches, producing no bindings.
@@ -33,30 +35,36 @@ use hulk_ast::{
 ///
 /// # Duplicate bindings
 /// If the same variable name appears more than once in a single pattern,
-/// the match fails (returns `None`). This prevents ambiguous captures.
-pub fn try_match(pattern: &MacroPattern, expr: &Expr) -> Option<HashMap<String, Expr>> {
+/// the match fails with `MacroErrorKind::DuplicatePatternBinding`.
+pub fn try_match(
+    pattern: &MacroPattern,
+    expr: &Expr,
+) -> Result<Option<HashMap<String, Expr>>, MacroErrorKind> {
     match pattern {
-        MacroPattern::Wildcard => Some(HashMap::new()),
+        MacroPattern::Wildcard => Ok(Some(HashMap::new())),
 
         MacroPattern::Literal(lit) => {
             if let ExprKind::Literal(ref e_lit) = expr.kind {
                 if e_lit == lit {
-                    return Some(HashMap::new());
+                    return Ok(Some(HashMap::new()));
                 }
             }
-            None
+            Ok(None)
         }
 
         MacroPattern::Bind { name, ty: _, pattern: inner } => {
-            let mut map = try_match(inner, expr)?;
-            if let Some(ref n) = name {
-                // Duplicate binding → fail the match.
-                if map.contains_key(n) {
-                    return None;
+            let inner_result = try_match(inner, expr)?;
+            if let Some(mut map) = inner_result {
+                if let Some(ref n) = name {
+                    if map.contains_key(n) {
+                        return Err(MacroErrorKind::DuplicatePatternBinding { name: n.clone() });
+                    }
+                    map.insert(n.clone(), expr.clone());
                 }
-                map.insert(n.clone(), expr.clone());
+                Ok(Some(map))
+            } else {
+                Ok(None)
             }
-            Some(map)
         }
 
         MacroPattern::BinaryExpr { op, left, right } => {
@@ -64,19 +72,28 @@ pub fn try_match(pattern: &MacroPattern, expr: &Expr) -> Option<HashMap<String, 
                 if bin.op == *op {
                     let left_map = match_bind(left, &bin.left)?;
                     let right_map = match_bind(right, &bin.right)?;
-                    return merge_maps(left_map, right_map);
+                    match (left_map, right_map) {
+                        (Some(l), Some(r)) => merge_maps(l, r).map(Some),
+                        _ => Ok(None),
+                    }
+                } else {
+                    Ok(None)
                 }
+            } else {
+                Ok(None)
             }
-            None
         }
 
         MacroPattern::UnaryExpr { op, operand } => {
             if let ExprKind::Unary(ref unary) = expr.kind {
                 if unary.op == *op {
-                    return match_bind(operand, &unary.expr);
+                    match_bind(operand, &unary.expr)
+                } else {
+                    Ok(None)
                 }
+            } else {
+                Ok(None)
             }
-            None
         }
     }
 }
@@ -89,37 +106,42 @@ pub fn try_match(pattern: &MacroPattern, expr: &Expr) -> Option<HashMap<String, 
 fn match_bind(
     bind: &MacroPatternBind,
     expr: &Expr,
-) -> Option<HashMap<String, Expr>> {
-    let mut map = try_match(&bind.pattern, expr)?;
-    if let Some(ref name) = bind.name {
-        if map.contains_key(name) {
-            return None;
+) -> Result<Option<HashMap<String, Expr>>, MacroErrorKind> {
+    let inner_result = try_match(&bind.pattern, expr)?;
+    if let Some(mut map) = inner_result {
+        if let Some(ref name) = bind.name {
+            if map.contains_key(name) {
+                return Err(MacroErrorKind::DuplicatePatternBinding { name: name.clone() });
+            }
+            map.insert(name.clone(), expr.clone());
         }
-        map.insert(name.clone(), expr.clone());
+        Ok(Some(map))
+    } else {
+        Ok(None)
     }
-    Some(map)
 }
 
-/// Merges two binding maps. Returns `None` if they share any key.
+/// Merges two binding maps. Returns `Err` if they share any key.
 fn merge_maps(
-    mut left: HashMap<String, Expr>,
+    left: HashMap<String, Expr>,
     right: HashMap<String, Expr>,
-) -> Option<HashMap<String, Expr>> {
+) -> Result<HashMap<String, Expr>, MacroErrorKind> {
+    let mut merged = left;
     for (k, v) in right {
-        if left.contains_key(&k) {
-            return None;
+        if merged.contains_key(&k) {
+            return Err(MacroErrorKind::DuplicatePatternBinding { name: k });
         }
-        left.insert(k, v);
+        merged.insert(k, v);
     }
-    Some(left)
+    Ok(merged)
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use hulk_ast::{
         BinaryOp, Expr, Literal, MacroPattern, MacroPatternBind, SourceSpan, UnaryOp,
     };
+    use crate::error::MacroErrorKind;
 
     fn s() -> SourceSpan {
         SourceSpan::new(1, 1)
@@ -172,29 +194,29 @@ mod tests {
         let pattern = MacroPattern::Wildcard;
         let expr = num(42.0);
         let result = try_match(&pattern, &expr);
-        assert_eq!(result, Some(HashMap::new()));
+        assert_eq!(result, Ok(Some(HashMap::new())));
     }
 
     #[test]
     fn literal_number_matches_exact() {
         let pattern = MacroPattern::Literal(Literal::Number(42.0));
-        assert!(try_match(&pattern, &num(42.0)).is_some());
-        assert!(try_match(&pattern, &num(43.0)).is_none());
-        assert!(try_match(&pattern, &bool_lit(true)).is_none());
+        assert_eq!(try_match(&pattern, &num(42.0)), Ok(Some(HashMap::new())));
+        assert_eq!(try_match(&pattern, &num(43.0)), Ok(None));
+        assert_eq!(try_match(&pattern, &bool_lit(true)), Ok(None));
     }
 
     #[test]
     fn literal_string_matches_exact() {
         let pattern = MacroPattern::Literal(Literal::String("hello".to_string()));
-        assert!(try_match(&pattern, &string_lit("hello")).is_some());
-        assert!(try_match(&pattern, &string_lit("world")).is_none());
+        assert_eq!(try_match(&pattern, &string_lit("hello")), Ok(Some(HashMap::new())));
+        assert_eq!(try_match(&pattern, &string_lit("world")), Ok(None));
     }
 
     #[test]
     fn literal_bool_matches_exact() {
         let pattern = MacroPattern::Literal(Literal::Boolean(true));
-        assert!(try_match(&pattern, &bool_lit(true)).is_some());
-        assert!(try_match(&pattern, &bool_lit(false)).is_none());
+        assert_eq!(try_match(&pattern, &bool_lit(true)), Ok(Some(HashMap::new())));
+        assert_eq!(try_match(&pattern, &bool_lit(false)), Ok(None));
     }
 
     #[test]
@@ -204,7 +226,7 @@ mod tests {
         let result = try_match(&pattern, &expr);
         let mut expected = HashMap::new();
         expected.insert("x".to_string(), expr.clone());
-        assert_eq!(result, Some(expected));
+        assert_eq!(result, Ok(Some(expected)));
     }
 
     #[test]
@@ -214,7 +236,7 @@ mod tests {
         let result = try_match(&pattern, &expr);
         let mut expected = HashMap::new();
         expected.insert("x".to_string(), expr.clone());
-        assert_eq!(result, Some(expected));
+        assert_eq!(result, Ok(Some(expected)));
     }
 
     #[test]
@@ -242,7 +264,7 @@ mod tests {
         expected.insert("whole".to_string(), expr.clone());
         expected.insert("left".to_string(), num(1.0));
         expected.insert("right".to_string(), num(2.0));
-        assert_eq!(result, Some(expected));
+        assert_eq!(result, Ok(Some(expected)));
     }
 
     #[test]
@@ -265,11 +287,11 @@ mod tests {
         let mut expected = HashMap::new();
         expected.insert("a".to_string(), num(1.0));
         expected.insert("b".to_string(), num(2.0));
-        assert_eq!(result, Some(expected));
+        assert_eq!(result, Ok(Some(expected)));
 
         // Wrong operator
         let expr2 = bin(BinaryOp::Subtract, num(1.0), num(2.0));
-        assert!(try_match(&pattern, &expr2).is_none());
+        assert_eq!(try_match(&pattern, &expr2), Ok(None));
     }
 
     #[test]
@@ -309,7 +331,7 @@ mod tests {
         expected.insert("x".to_string(), num(1.0));
         expected.insert("y".to_string(), num(2.0));
         expected.insert("z".to_string(), num(3.0));
-        assert_eq!(result, Some(expected));
+        assert_eq!(result, Ok(Some(expected)));
     }
 
     #[test]
@@ -326,11 +348,11 @@ mod tests {
         let result = try_match(&pattern, &expr);
         let mut expected = HashMap::new();
         expected.insert("x".to_string(), num(42.0));
-        assert_eq!(result, Some(expected));
+        assert_eq!(result, Ok(Some(expected)));
 
         // Wrong operator
         let expr2 = un(UnaryOp::Not, bool_lit(true));
-        assert!(try_match(&pattern, &expr2).is_none());
+        assert_eq!(try_match(&pattern, &expr2), Ok(None));
     }
 
     #[test]
@@ -350,7 +372,8 @@ mod tests {
             }),
         };
         let expr = bin(BinaryOp::Add, num(1.0), num(2.0));
-        assert!(try_match(&pattern, &expr).is_none());
+        let err = try_match(&pattern, &expr).expect_err("should be duplicate binding error");
+        assert!(matches!(err, MacroErrorKind::DuplicatePatternBinding { name } if name == "x"));
     }
 
     #[test]
@@ -386,7 +409,8 @@ mod tests {
             num(1.0),
             bin(BinaryOp::Multiply, num(2.0), num(3.0)),
         );
-        assert!(try_match(&pattern, &expr).is_none());
+        let err = try_match(&pattern, &expr).expect_err("should be duplicate binding error");
+        assert!(matches!(err, MacroErrorKind::DuplicatePatternBinding { name } if name == "x"));
     }
 
     #[test]
@@ -406,6 +430,6 @@ mod tests {
         };
         let expr = bin(BinaryOp::Add, num(1.0), num(2.0));
         let result = try_match(&pattern, &expr);
-        assert_eq!(result, Some(HashMap::new()));
+        assert_eq!(result, Ok(Some(HashMap::new())));
     }
 }

--- a/crates/hulk-transpile/src/pattern.rs
+++ b/crates/hulk-transpile/src/pattern.rs
@@ -7,51 +7,11 @@
 // On success, it returns a mapping from capture variable names to the
 // matched sub‑expressions. The expansion engine in `substitute.rs` uses this
 // to implement compile‑time `match` inside macro bodies.
-//
-// NOTE: This file is a placeholder. The matching logic is not yet implemented;
-// `try_match` currently returns `None` for every pattern. Once implemented,
-// it will be called from `substitute.rs` when encountering an `ExprKind::Match`
-// whose scrutinee is a concrete AST node (i.e., inside an expanding macro).
 
 use std::collections::HashMap;
-use hulk_ast::{BinaryOp, Expr, Literal, TypeRef, UnaryOp};
-use crate::error::MacroError;
-
-/// A pattern that can be matched against an expression AST at compile time.
-#[derive(Debug, Clone)]
-pub enum MacroPattern {
-    /// Matches any expression (wildcard).
-    Wildcard,
-    /// Matches a specific literal value (integer, string, boolean, etc.).
-    Literal(Literal),
-    /// Matches a binary expression with a specific operator, and binds
-    /// the left and right operands (which themselves may contain patterns).
-    BinaryExpr {
-        op: BinaryOp,
-        left: Box<MacroPatternBind>,
-        right: Box<MacroPatternBind>,
-    },
-    /// Matches a unary expression with a specific operator.
-    UnaryExpr {
-        op: UnaryOp,
-        operand: Box<MacroPatternBind>,
-    },
-    // Future: constructor patterns, list patterns, etc.
-}
-
-/// A binding site in a macro pattern. It may include a variable name to
-/// capture the matched subtree, an optional type constraint (not yet used
-/// by matching, but available for consistency checks), and a sub‑pattern.
-#[derive(Debug, Clone)]
-pub struct MacroPatternBind {
-    /// If `Some`, the matched sub‑expression will be bound to this name
-    /// in the substitution map (allowing it to be used in the case body).
-    pub name: Option<String>,
-    /// Optional type annotation (for documentation / future type checking).
-    pub ty: Option<TypeRef>,
-    /// The shape this binding must match.
-    pub pattern: MacroPattern,
-}
+use hulk_ast::{
+    Expr, ExprKind, MacroPattern, MacroPatternBind,
+};
 
 /// Attempts to match a `pattern` against the concrete AST node `expr`.
 ///
@@ -60,56 +20,392 @@ pub struct MacroPatternBind {
 ///   capture variable name to the `Expr` subtree that was matched.
 /// - `None` if the pattern does not match.
 ///
-/// # How it will work:
+/// # Matching rules
 /// - `MacroPattern::Wildcard` always matches, producing no bindings.
 /// - `MacroPattern::Literal(lit)` matches only if `expr` is a literal with
 ///   the same value.
+/// - `MacroPattern::Bind` recursively matches its inner pattern; if successful
+///   and the bind has a `name`, the matched expression is inserted into the map.
 /// - `MacroPattern::BinaryExpr` matches an `ExprKind::Binary` node with the
-///   given operator, then recursively matches the left and right sides. The
-///   bindings from both sides are merged (duplicate variable names are not
-///   allowed in a single pattern, and will cause a match failure).
+///   given operator, then recursively matches the left and right operands
+///   (using `MacroPatternBind` to capture them if named).
 /// - `MacroPattern::UnaryExpr` matches an `ExprKind::Unary` node similarly.
-/// - `MacroPatternBind` captures the matched subtree under `name` if present.
 ///
-/// # Integration
-/// In `substitute.rs`, when expanding a macro and encountering a
-/// `MacroMatchExpr` (an expression of the form `match(scrutinee) { cases }`),
-/// the engine will:
-/// 1. Ensure `scrutinee` has already been substituted to a concrete `Expr`.
-/// 2. For each case, convert the pattern AST into a `MacroPattern` (using a
-///    helper from this module).
-/// 3. Call `try_match(&pattern, &scrutinee_expr)`.
-/// 4. If it returns bindings, merge them into the `SubstMap` and expand the
-///    corresponding case body.
-pub fn try_match(
-    pattern: &MacroPattern,
-    _expr: &Expr,
-) -> Option<HashMap<String, Expr>> {
-    // Placeholder: no patterns match yet. The real implementation will be added
-    // after the basic macro system (Phase 1) is stable.
+/// # Duplicate bindings
+/// If the same variable name appears more than once in a single pattern,
+/// the match fails (returns `None`). This prevents ambiguous captures.
+pub fn try_match(pattern: &MacroPattern, expr: &Expr) -> Option<HashMap<String, Expr>> {
     match pattern {
-        MacroPattern::Wildcard => Some(HashMap::new()), // always matches, no bindings
-        MacroPattern::Literal(_) => None,               // TODO
-        MacroPattern::BinaryExpr { .. } => None,        // TODO
-        MacroPattern::UnaryExpr { .. } => None,         // TODO
+        MacroPattern::Wildcard => Some(HashMap::new()),
+
+        MacroPattern::Literal(lit) => {
+            if let ExprKind::Literal(ref e_lit) = expr.kind {
+                if e_lit == lit {
+                    return Some(HashMap::new());
+                }
+            }
+            None
+        }
+
+        MacroPattern::Bind { name, ty: _, pattern: inner } => {
+            let mut map = try_match(inner, expr)?;
+            if let Some(ref n) = name {
+                // Duplicate binding → fail the match.
+                if map.contains_key(n) {
+                    return None;
+                }
+                map.insert(n.clone(), expr.clone());
+            }
+            Some(map)
+        }
+
+        MacroPattern::BinaryExpr { op, left, right } => {
+            if let ExprKind::Binary(ref bin) = expr.kind {
+                if bin.op == *op {
+                    let left_map = match_bind(left, &bin.left)?;
+                    let right_map = match_bind(right, &bin.right)?;
+                    return merge_maps(left_map, right_map);
+                }
+            }
+            None
+        }
+
+        MacroPattern::UnaryExpr { op, operand } => {
+            if let ExprKind::Unary(ref unary) = expr.kind {
+                if unary.op == *op {
+                    return match_bind(operand, &unary.expr);
+                }
+            }
+            None
+        }
     }
 }
 
-/// Converts a parsed match‑case pattern (produced by the parser for macro bodies)
-/// into a `MacroPattern` for compile‑time matching.
+/// Matches a `MacroPatternBind` against an expression.
 ///
-/// # Parameters
-/// - `pat_ast`: the pattern AST node as returned by the parser (e.g., a `PatternExpr`).
-///
-/// # Returns
-/// - `Ok(MacroPattern)` on successful conversion.
-/// - `Err(MacroError)` if the pattern is malformed or contains unsupported constructs.
-///
-/// This function will be implemented in when implementing structural pattern matching.
-///  It is called from `substitute.rs` when expanding a macro‑local `match` expression.
-pub fn pattern_from_ast(_pat_ast: &Expr) -> Result<MacroPattern, MacroError> {
-    // TODO: implement AST → pattern conversion
-    // Mapping examples:
-    //   `(x:Number + 0)` → BinaryExpr{op:Add, left:Bind(Some("x"), Number, Wildcard), right:Bind(None, None, Literal(0))}
-    todo!("Convert parsed pattern to MacroPattern")
+/// This first recursively matches the inner pattern. If that succeeds and the
+/// bind has a `name`, the whole expression is inserted into the bindings map
+/// under that name. The optional type annotation (`ty`) is ignored during matching.
+fn match_bind(
+    bind: &MacroPatternBind,
+    expr: &Expr,
+) -> Option<HashMap<String, Expr>> {
+    let mut map = try_match(&bind.pattern, expr)?;
+    if let Some(ref name) = bind.name {
+        if map.contains_key(name) {
+            return None;
+        }
+        map.insert(name.clone(), expr.clone());
+    }
+    Some(map)
+}
+
+/// Merges two binding maps. Returns `None` if they share any key.
+fn merge_maps(
+    mut left: HashMap<String, Expr>,
+    right: HashMap<String, Expr>,
+) -> Option<HashMap<String, Expr>> {
+    for (k, v) in right {
+        if left.contains_key(&k) {
+            return None;
+        }
+        left.insert(k, v);
+    }
+    Some(left)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hulk_ast::{
+        BinaryOp, Expr, Literal, MacroPattern, MacroPatternBind, SourceSpan, UnaryOp,
+    };
+
+    fn s() -> SourceSpan {
+        SourceSpan::new(1, 1)
+    }
+
+    fn num(n: f64) -> Expr {
+        Expr::number(n, s())
+    }
+
+    fn bool_lit(b: bool) -> Expr {
+        Expr::boolean(b, s())
+    }
+
+    fn string_lit(st: &str) -> Expr {
+        Expr::string(st, s())
+    }
+
+    fn _var(name: &str) -> Expr {
+        Expr::variable(name, s())
+    }
+
+    fn bin(op: BinaryOp, left: Expr, right: Expr) -> Expr {
+        Expr::binary(op, left, right, s())
+    }
+
+    fn un(op: UnaryOp, expr: Expr) -> Expr {
+        Expr::unary(op, expr, s())
+    }
+
+    // Helper to create a Bind pattern with a name and inner pattern.
+    fn bind(name: &str, pattern: MacroPattern) -> MacroPattern {
+        MacroPattern::Bind {
+            name: Some(name.to_string()),
+            ty: None,
+            pattern: Box::new(pattern),
+        }
+    }
+
+    // Helper to create a Bind pattern with type annotation.
+    fn bind_ty(name: &str, ty: &str, pattern: MacroPattern) -> MacroPattern {
+        MacroPattern::Bind {
+            name: Some(name.to_string()),
+            ty: Some(hulk_ast::TypeRef::named(ty)),
+            pattern: Box::new(pattern),
+        }
+    }
+
+    #[test]
+    fn wildcard_matches_anything() {
+        let pattern = MacroPattern::Wildcard;
+        let expr = num(42.0);
+        let result = try_match(&pattern, &expr);
+        assert_eq!(result, Some(HashMap::new()));
+    }
+
+    #[test]
+    fn literal_number_matches_exact() {
+        let pattern = MacroPattern::Literal(Literal::Number(42.0));
+        assert!(try_match(&pattern, &num(42.0)).is_some());
+        assert!(try_match(&pattern, &num(43.0)).is_none());
+        assert!(try_match(&pattern, &bool_lit(true)).is_none());
+    }
+
+    #[test]
+    fn literal_string_matches_exact() {
+        let pattern = MacroPattern::Literal(Literal::String("hello".to_string()));
+        assert!(try_match(&pattern, &string_lit("hello")).is_some());
+        assert!(try_match(&pattern, &string_lit("world")).is_none());
+    }
+
+    #[test]
+    fn literal_bool_matches_exact() {
+        let pattern = MacroPattern::Literal(Literal::Boolean(true));
+        assert!(try_match(&pattern, &bool_lit(true)).is_some());
+        assert!(try_match(&pattern, &bool_lit(false)).is_none());
+    }
+
+    #[test]
+    fn bind_captures_expression() {
+        let pattern = bind("x", MacroPattern::Wildcard);
+        let expr = num(42.0);
+        let result = try_match(&pattern, &expr);
+        let mut expected = HashMap::new();
+        expected.insert("x".to_string(), expr.clone());
+        assert_eq!(result, Some(expected));
+    }
+
+    #[test]
+    fn bind_with_type_ignores_type_during_matching() {
+        let pattern = bind_ty("x", "Number", MacroPattern::Wildcard);
+        let expr = string_lit("hello");
+        let result = try_match(&pattern, &expr);
+        let mut expected = HashMap::new();
+        expected.insert("x".to_string(), expr.clone());
+        assert_eq!(result, Some(expected));
+    }
+
+    #[test]
+    fn bind_on_compound_pattern_captures_whole() {
+        let pattern = MacroPattern::Bind {
+            name: Some("whole".to_string()),
+            ty: None,
+            pattern: Box::new(MacroPattern::BinaryExpr {
+                op: BinaryOp::Add,
+                left: Box::new(MacroPatternBind {
+                    name: Some("left".to_string()),
+                    ty: None,
+                    pattern: MacroPattern::Wildcard,
+                }),
+                right: Box::new(MacroPatternBind {
+                    name: Some("right".to_string()),
+                    ty: None,
+                    pattern: MacroPattern::Wildcard,
+                }),
+            }),
+        };
+        let expr = bin(BinaryOp::Add, num(1.0), num(2.0));
+        let result = try_match(&pattern, &expr);
+        let mut expected = HashMap::new();
+        expected.insert("whole".to_string(), expr.clone());
+        expected.insert("left".to_string(), num(1.0));
+        expected.insert("right".to_string(), num(2.0));
+        assert_eq!(result, Some(expected));
+    }
+
+    #[test]
+    fn binary_expr_matches_operator_and_binds_operands() {
+        let pattern = MacroPattern::BinaryExpr {
+            op: BinaryOp::Add,
+            left: Box::new(MacroPatternBind {
+                name: Some("a".to_string()),
+                ty: None,
+                pattern: MacroPattern::Wildcard,
+            }),
+            right: Box::new(MacroPatternBind {
+                name: Some("b".to_string()),
+                ty: None,
+                pattern: MacroPattern::Wildcard,
+            }),
+        };
+        let expr = bin(BinaryOp::Add, num(1.0), num(2.0));
+        let result = try_match(&pattern, &expr);
+        let mut expected = HashMap::new();
+        expected.insert("a".to_string(), num(1.0));
+        expected.insert("b".to_string(), num(2.0));
+        assert_eq!(result, Some(expected));
+
+        // Wrong operator
+        let expr2 = bin(BinaryOp::Subtract, num(1.0), num(2.0));
+        assert!(try_match(&pattern, &expr2).is_none());
+    }
+
+    #[test]
+    fn binary_expr_with_nested_patterns() {
+        let pattern = MacroPattern::BinaryExpr {
+            op: BinaryOp::Multiply,
+            left: Box::new(MacroPatternBind {
+                name: None,
+                ty: None,
+                pattern: MacroPattern::BinaryExpr {
+                    op: BinaryOp::Add,
+                    left: Box::new(MacroPatternBind {
+                        name: Some("x".to_string()),
+                        ty: None,
+                        pattern: MacroPattern::Wildcard,
+                    }),
+                    right: Box::new(MacroPatternBind {
+                        name: Some("y".to_string()),
+                        ty: None,
+                        pattern: MacroPattern::Wildcard,
+                    }),
+                },
+            }),
+            right: Box::new(MacroPatternBind {
+                name: Some("z".to_string()),
+                ty: None,
+                pattern: MacroPattern::Wildcard,
+            }),
+        };
+        let expr = bin(
+            BinaryOp::Multiply,
+            bin(BinaryOp::Add, num(1.0), num(2.0)),
+            num(3.0),
+        );
+        let result = try_match(&pattern, &expr);
+        let mut expected = HashMap::new();
+        expected.insert("x".to_string(), num(1.0));
+        expected.insert("y".to_string(), num(2.0));
+        expected.insert("z".to_string(), num(3.0));
+        assert_eq!(result, Some(expected));
+    }
+
+    #[test]
+    fn unary_expr_matches_operator_and_binds_operand() {
+        let pattern = MacroPattern::UnaryExpr {
+            op: UnaryOp::Negate,
+            operand: Box::new(MacroPatternBind {
+                name: Some("x".to_string()),
+                ty: None,
+                pattern: MacroPattern::Wildcard,
+            }),
+        };
+        let expr = un(UnaryOp::Negate, num(42.0));
+        let result = try_match(&pattern, &expr);
+        let mut expected = HashMap::new();
+        expected.insert("x".to_string(), num(42.0));
+        assert_eq!(result, Some(expected));
+
+        // Wrong operator
+        let expr2 = un(UnaryOp::Not, bool_lit(true));
+        assert!(try_match(&pattern, &expr2).is_none());
+    }
+
+    #[test]
+    fn duplicate_bindings_are_rejected() {
+        // Pattern: (x + x) – binding `x` twice
+        let pattern = MacroPattern::BinaryExpr {
+            op: BinaryOp::Add,
+            left: Box::new(MacroPatternBind {
+                name: Some("x".to_string()),
+                ty: None,
+                pattern: MacroPattern::Wildcard,
+            }),
+            right: Box::new(MacroPatternBind {
+                name: Some("x".to_string()),
+                ty: None,
+                pattern: MacroPattern::Wildcard,
+            }),
+        };
+        let expr = bin(BinaryOp::Add, num(1.0), num(2.0));
+        assert!(try_match(&pattern, &expr).is_none());
+    }
+
+    #[test]
+    fn duplicate_bindings_across_nested_patterns() {
+        // Pattern: (x + (x * 2)) – x appears twice
+        let pattern = MacroPattern::BinaryExpr {
+            op: BinaryOp::Add,
+            left: Box::new(MacroPatternBind {
+                name: Some("x".to_string()),
+                ty: None,
+                pattern: MacroPattern::Wildcard,
+            }),
+            right: Box::new(MacroPatternBind {
+                name: None,
+                ty: None,
+                pattern: MacroPattern::BinaryExpr {
+                    op: BinaryOp::Multiply,
+                    left: Box::new(MacroPatternBind {
+                        name: Some("x".to_string()),
+                        ty: None,
+                        pattern: MacroPattern::Wildcard,
+                    }),
+                    right: Box::new(MacroPatternBind {
+                        name: Some("y".to_string()),
+                        ty: None,
+                        pattern: MacroPattern::Wildcard,
+                    }),
+                },
+            }),
+        };
+        let expr = bin(
+            BinaryOp::Add,
+            num(1.0),
+            bin(BinaryOp::Multiply, num(2.0), num(3.0)),
+        );
+        assert!(try_match(&pattern, &expr).is_none());
+    }
+
+    #[test]
+    fn wildcard_does_not_bind() {
+        let pattern = MacroPattern::BinaryExpr {
+            op: BinaryOp::Add,
+            left: Box::new(MacroPatternBind {
+                name: None,
+                ty: None,
+                pattern: MacroPattern::Wildcard,
+            }),
+            right: Box::new(MacroPatternBind {
+                name: None,
+                ty: None,
+                pattern: MacroPattern::Wildcard,
+            }),
+        };
+        let expr = bin(BinaryOp::Add, num(1.0), num(2.0));
+        let result = try_match(&pattern, &expr);
+        assert_eq!(result, Some(HashMap::new()));
+    }
 }

--- a/crates/hulk-transpile/src/substitute.rs
+++ b/crates/hulk-transpile/src/substitute.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use hulk_ast::{
     AssignExpr, AssignTarget, BlockExpr, DowncastExpr, ElifBranch, Expr, ExprKind, ForExpr,
     IndexExpr, LetBinding, LetExpr, MacroArg, MatchCase, MemberExpr, NewExpr, TypeTestExpr, 
-    UnaryExpr, VectorComprehension, VectorExpr, WhileExpr,
+    UnaryExpr, VectorComprehension, VectorExpr, WhileExpr, MacroCase, MacroMatchExpr,
 };
 
 /// Substitution map for a single macro expansion.
@@ -299,6 +299,23 @@ pub fn substitute(expr: &Expr, subst: &SubstMap) -> Expr {
             )),
             expr.span,
         ),
+        ExprKind::MacroMatch(mm) => {
+            let new_scrutinee = substitute(&mm.scrutinee, subst);
+            let new_cases = mm.cases
+                .iter()
+                .map(|case| MacroCase {
+                    pattern: case.pattern.clone(), // patterns are not substituted
+                    body: substitute(&case.body, subst),
+                })
+                .collect();
+            Expr::new(
+                ExprKind::MacroMatch(MacroMatchExpr {
+                    scrutinee: Box::new(new_scrutinee),
+                    cases: new_cases,
+                }),
+                expr.span,
+            )
+        }
         // Leaf nodes are returned unchanged.
         _ => expr.clone(),
     }


### PR DESCRIPTION
## What does this PR do?
This PR implements compile‑time structural pattern matching inside macro definitions. It enables macros to deconstruct their arguments based on the shape of the AST and generate code accordingly, e.g. simplify macro that optimises arithmetic expressions at compile time. The implementation spans the entire compiler pipeline: AST, parser, macro expansion (transpile), semantic analysis (as a safety net), code generation, and a full set of golden integration tests.

## Related Issue
This feature was previously a placeholder; now fully functional.

## Changes
### AST (`hulk-ast`)
- Added `MacroPattern`, `MacroPatternBind`, `MacroCase`, `MacroMatchExpr`, and `ExprKind::MacroMatch` to represent compile‑time match expressions.
- Updated `walk_expr` to traverse `MacroMatch` nodes.

### Parser (`hulk-parser`)
- Introduced `in_macro_body` flag to distinguish macro bodies from runtime code.
- Implemented `parse_macro_match_expr()` to parse:
  ```
  match ( <scrutinee> ) {
      case ( <pattern> ) => <body> ;
      ...
      default => <body> ;
  }
  ```
- Added a full precedence‑based pattern parser (`parse_macro_pattern_or`, `and`, `equality`, …) with support for literals, identifiers with optional type annotations, compound binding (`name: (pattern)`), parenthesised sub‑patterns, binary/unary operators, and wildcard `_`.
- Fixed a bug in `parse_macro_pattern_term` where `+`/`-` were not consumed correctly, and used `parse_named_type_ref` to avoid confusion with iterable sugar `*`.

### Macro Expansion (`hulk-transpile`)
- Implemented `try_match()` in `pattern.rs` to compare a `MacroPattern` against a concrete AST node, returning captured bindings. Supports `Wildcard`, `Literal`, `Bind`, `BinaryExpr`, and `UnaryExpr` with duplicate binding detection.
- Integrated `MacroMatch` handling into `expand_expr()`: expands scrutinee, tries cases in order, builds a substitution map from successful bindings, substitutes the case body, and recursively expands the result.
- Added `NonExhaustiveMacroMatch` error variant and proper error propagation.

### Semantic Analysis (`hulk-semantic`)
- Added explicit handling for `ExprKind::MacroMatch` in `infer.rs`, `check.rs`, and `resolve_constructor_params.rs`, reporting `MacroReferenceFound` if a macro match survives expansion (internal pipeline error).

### Code Generation (`hulk-codegen`)
- Added golden integration tests for all macro examples from the specification: `repeat`, `swap`, `repeat` with placeholder, `simplify`, default branch, nested macros, and macro returning a value.
- Fixed runtime library path resolution in tests (`ensure_rt_built` and `link_output`) to correctly locate `libhulk_rt.a` regardless of build profile.
- Fixed reference‑counting bug in `lower_let` by retaining borrowed values when a `let` initializer is a variable or member access.

### Documentation
- Updated `GRAMMAR_LL1.md` with the new macro pattern matching grammar and implementation map.

## How to test
1. Run the full test suite:
```bash
cargo test -p hulk-codegen -- --test macro_tests
```

2. Write a custom macro with pattern matching, e.g.:
```hulk
def simplify(expr:Number) {
    match(expr) {
        case (x:Number + 0) => x;
        default => expr;
    }
}
print(simplify(42 + 0));
```